### PR TITLE
Ensure the "does not exist" error message is shown for missing devices

### DIFF
--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -1,0 +1,20 @@
+import click
+import pytest
+
+from universal_silabs_flasher.flash import SerialPort
+
+
+def test_click_serialport_validation():
+    assert SerialPort().convert("/dev/null", None, None) == "/dev/null"
+    assert SerialPort().convert("COM123", None, None) == "COM123"
+    assert SerialPort().convert("socket://1.2.3.4", None, None) == "socket://1.2.3.4"
+
+    with pytest.raises(click.BadParameter) as exc_info:
+        assert SerialPort().convert("http://1.2.3.4", None, None)
+
+    assert "invalid URL scheme" in exc_info.value.message
+
+    with pytest.raises(click.BadParameter) as exc_info:
+        assert SerialPort().convert("/dev/serial/by-id/does-not-exist", None, None)
+
+    assert "does not exist" in exc_info.value.message

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -81,18 +81,18 @@ class SerialPort(click.ParamType):
             parsed = urllib.parse.urlparse(value)
         except ValueError:
             self.fail(f"Invalid URI: {path}", param, ctx)
-        else:
-            if parsed.scheme == "socket":
-                return value
 
+        if parsed.scheme == "socket":
+            return value
+        elif parsed.scheme != "":
             self.fail(
                 f"invalid URL scheme {parsed.scheme!r}, only `socket://` is accepted",
                 param,
                 ctx,
             )
-
-        # Fallback
-        self.fail(f"{path} does not exist", param, ctx)
+        else:
+            # Fallback
+            self.fail(f"{path} does not exist", param, ctx)
 
 
 @click.group()


### PR DESCRIPTION
If a device path did not exist, the URI error message was presented by mistake.