### PR TITLE
Allow specifying COM ports larger than 10

### DIFF
--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -6,8 +6,12 @@ from universal_silabs_flasher.flash import SerialPort
 
 def test_click_serialport_validation():
     assert SerialPort().convert("/dev/null", None, None) == "/dev/null"
-    assert SerialPort().convert("COM123", None, None) == "COM123"
     assert SerialPort().convert("socket://1.2.3.4", None, None) == "socket://1.2.3.4"
+    assert SerialPort().convert("COM1", None, None) == "COM1"
+    assert SerialPort().convert("\\\\.\\COM123", None, None) == "\\\\.\\COM123"
+
+    with pytest.raises(click.BadParameter) as exc_info:
+        assert SerialPort().convert("COM10", None, None)
 
     with pytest.raises(click.BadParameter) as exc_info:
         assert SerialPort().convert("http://1.2.3.4", None, None)

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import enum
 import typing
 import asyncio
@@ -72,8 +73,8 @@ class SerialPort(click.ParamType):
         if path.exists():
             return value
 
-        # Windows COM port
-        if value.startswith("COM") and value[3:].isdigit():
+        # Windows COM port (COM10+ uses a different syntax)
+        if re.match(r"^COM[0-9]$|\\\\\.\\COM[0-9]+$", str(path)):
             return value
 
         # Socket URI


### PR DESCRIPTION
`COM10` and above must be specified as `\\.\COM10`.