### PR TITLE
Implement the Spinel+HDLCLite protocol

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,6 @@ repos:
     rev: v0.991
     hooks:
       - id: mypy
-        additional_dependencies:
-          - zigpy
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
     rev: v0.991
     hooks:
       - id: mypy
+        additional_dependencies:
+          - zigpy
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1

--- a/README.md
+++ b/README.md
@@ -1,9 +1,30 @@
 # Universal Silicon Labs Flasher
-Automatically communicates with radios over CPC or EZSP to enter the bootloader and then flashes a firmware image with XMODEM.
+Automatically communicates with radios over CPC, EZSP, or Spinel to enter the bootloader and then flashes a firmware image with XMODEM.
 
 ## Installation
 ```console
 $ pip install universal-silabs-flasher
+```
+
+## Usage
+
+```console
+Usage: universal-silabs-flasher [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  -v, --verbose
+  --device PATH_OR_URL           [required]
+  --baudrate INTEGER             [default: 115200]
+  --bootloader-baudrate INTEGER  [default: 115200]
+  --cpc-baudrate INTEGER         [default: 115200]
+  --ezsp-baudrate INTEGER        [default: 115200]
+  --spinel-baudrate INTEGER      [default: 460800]
+  --probe-method TEXT            [default: bootloader, cpc, ezsp, spinel]
+  --help                         Show this message and exit.
+
+Commands:
+  flash
+  write-ieee
 ```
 
 ## Flashing firmware

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ In addition to validating the firmware image, the version number of the firmware
 
  - If the provided firmware image type does not match the running image type, the firmware will not be flashed. Cross-flashing can be enabled with `--allow-cross-flashing`.
  - If the provided firmware image is a lower version than the currently running image, the downgrade will not be allowed. Downgrades can be enabled with `--allow-downgrades`.
- - If the provided firmware image already matches the version running on the device, the command will exit early. Firmware re-flashing can be enabled with `--allow-reflash-same-version`.
+ - To always upgrade/downgrade firmware to a specific version (i.e. as the entry point for an addon bundling firmware), use `--ensure-exact-version`.
+ - All of the above logic can be skipped with `--force`.
 
 ### Yellow
 The Yellow's bootloader can always be activated with the `--yellow-gpio-reset` flag:
@@ -21,8 +22,6 @@ The Yellow's bootloader can always be activated with the `--yellow-gpio-reset` f
 ```bash
 $ universal-silabs-flasher \
     --device /dev/ttyAMA1 \
-    --bootloader-baudrate 115200 \
-    --baudrate 115200 \
     flash \
     --firmware NabuCasa_RCP_v4.1.3_rcp-uart-hw-802154_230400.gbl \
     --yellow-gpio-reset
@@ -34,8 +33,6 @@ The SkyConnect will be rebooted into its bootloader from the running application
 ```bash
 $ universal-silabs-flasher \
     --device /dev/cu.SLAB_USBtoUART \
-    --bootloader-baudrate 115200 \
-    --baudrate 115200 \
     flash \
     --firmware NabuCasa_SkyConnect_EZSP_v7.1.3.0_ncp-uart-hw_115200.gbl
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ python_requires = >=3.8
 install_requires =
     click
     zigpy
+    crc
     bellows>=0.34.3
     gpiod; platform_system=="Linux"
     coloredlogs

--- a/tests/test_spinel.py
+++ b/tests/test_spinel.py
@@ -1,0 +1,65 @@
+import pytest
+
+import universal_silabs_flasher.spinel as spinel
+from universal_silabs_flasher.common import crc16_kermit
+
+
+@pytest.mark.parametrize(
+    "data, crc",
+    [
+        (b"", 0x0000),
+        (b"foobar", 0x147B),
+        (b"\xfa\x9b\x51\xb9\xf2\x53\xe3\xbd", 0x6782),
+    ],
+)
+def test_hdlc_lite_crc(data, crc):
+    assert crc16_kermit(data) == crc
+
+
+@pytest.mark.parametrize(
+    "encoded, decoded",
+    [
+        (bytes.fromhex("7e810243d3d37e"), bytes.fromhex("810243")),
+        (bytes.fromhex("7e8103367d5e7d5d6af97e"), bytes.fromhex("8103367e7d")),
+        (bytes.fromhex("7e810365010b287e"), bytes.fromhex("81036501")),
+        (bytes.fromhex("7e8103862a01547d5e7e"), bytes.fromhex("8103862a01")),
+        (
+            bytes.fromhex(
+                "7e8106024f50454e5448524541442f366666316163302d64697274793b204546523332"
+                "3b2044656320323320323032322031383a30383a303000fa8c7e"
+            ),
+            bytes.fromhex(
+                "8106024f50454e5448524541442f366666316163302d64697274793b2045465233323b"
+                "2044656320323320323032322031383a30383a303000"
+            ),
+        ),
+    ],
+)
+def test_hdlc_lite_encoding_decoding(encoded, decoded):
+    assert spinel.HDLCLiteFrame(data=decoded).serialize() == encoded
+    assert spinel.HDLCLiteFrame.from_bytes(encoded).data == decoded
+
+
+@pytest.mark.parametrize(
+    "encoded, decoded",
+    [
+        (
+            bytes.fromhex(
+                "8106024f50454e5448524541442f366666316163302d64697274793b2045465233323b"
+                "2044656320323320323032322031383a30383a303000"
+            ),
+            spinel.SpinelFrame(
+                header=spinel.SpinelHeader(
+                    transaction_id=1,
+                    network_link_id=0,
+                    flag=0b10,
+                ),
+                command_id=spinel.CommandID.PROP_VALUE_IS,
+                data=b"\x02OPENTHREAD/6ff1ac0-dirty; EFR32; Dec 23 2022 18:08:00\x00",
+            ),
+        ),
+    ],
+)
+def test_spinel_parsing(encoded, decoded):
+    assert spinel.SpinelFrame.from_bytes(encoded) == decoded
+    assert decoded.serialize() == encoded

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import typing
 import asyncio
 import logging
-import binascii
 import contextlib
 import collections
 
+import crc
 import zigpy.serial
 import async_timeout
 import serial_asyncio
@@ -17,9 +17,21 @@ CONNECT_TIMEOUT = 1
 PROBE_TIMEOUT = 2
 
 
+CRC_CCITT = crc.Calculator(
+    crc.Configuration(
+        width=16,
+        polynomial=0x1021,
+        init_value=0x0000,
+        final_xor_value=0x0000,
+        reverse_input=False,
+        reverse_output=False,
+    )
+)
+
+
 # Used by both CPC and XModem
 def crc16_ccitt(data: bytes) -> int:
-    return binascii.crc_hqx(data, 0x0000)
+    return CRC_CCITT.checksum(data)
 
 
 class BufferTooShort(Exception):

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -28,10 +28,26 @@ CRC_CCITT = crc.Calculator(
     )
 )
 
+CRC_KERMIT = crc.Calculator(
+    crc.Configuration(
+        width=16,
+        polynomial=0x1021,
+        init_value=0xFFFF,
+        final_xor_value=0xFFFF,
+        reverse_input=True,
+        reverse_output=True,
+    )
+)
+
 
 # Used by both CPC and XModem
 def crc16_ccitt(data: bytes) -> int:
     return CRC_CCITT.checksum(data)
+
+
+# Used by HDLC-Lite
+def crc16_kermit(data: bytes) -> int:
+    return CRC_KERMIT.checksum(data)
 
 
 class BufferTooShort(Exception):

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -14,6 +14,7 @@ import click
 import coloredlogs
 import zigpy.types
 import bellows.types
+import zigpy.ota.validators
 
 from .gbl import GBLImage, FirmwareImageType
 from .common import patch_pyserial_asyncio
@@ -208,7 +209,12 @@ async def flash(
     firmware_data = firmware.read()
     firmware.close()
 
-    gbl_image = GBLImage.from_bytes(firmware_data)
+    try:
+        gbl_image = GBLImage.from_bytes(firmware_data)
+    except zigpy.ota.validators.ValidationError as e:
+        raise click.ClickException(
+            f"{firmware.name!r} does not appear to be a valid GBL image: {e!r}"
+        )
 
     try:
         metadata = gbl_image.get_nabucasa_metadata()

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -14,7 +14,7 @@ import bellows.config
 from awesomeversion import AwesomeVersion
 
 from .cpc import CPCProtocol
-from .gbl import GBLImage
+from .gbl import GBLImage, FirmwareImageType
 from .common import PROBE_TIMEOUT, connect_protocol
 from .spinel import SpinelProtocol
 from .emberznet import connect_ezsp
@@ -68,6 +68,14 @@ class ApplicationType(enum.Enum):
     CPC = "cpc"
     EZSP = "ezsp"
     SPINEL = "spinel"
+
+
+FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
+    FirmwareImageType.NCP_UART_HW: ApplicationType.GECKO_BOOTLOADER,
+    FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
+    FirmwareImageType.ZIGBEE_NCP_RCP_UART_802154: ApplicationType.CPC,
+    FirmwareImageType.OT_RCP: ApplicationType.SPINEL,
+}
 
 
 DEFAULT_BAUDRATES = {

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -59,16 +59,22 @@ class FirmwareImageType(enum.Enum):
     # Zigbee NCP + OpenThread RCP
     ZIGBEE_NCP_RCP_UART_802154 = "zigbee-ncp-rcp-uart-802154"
 
+    # OpenThread RCP
+    OT_RCP = "ot-rcp"
+
 
 @dataclasses.dataclass(frozen=True)
 class NabuCasaMetadata:
     metadata_version: int
+
     sdk_version: AwesomeVersion | None
     ezsp_version: AwesomeVersion | None
+    ot_rcp_version: AwesomeVersion | None
+
     fw_type: FirmwareImageType | None
 
     def get_public_version(self) -> AwesomeVersion | None:
-        return self.ezsp_version or self.sdk_version
+        return self.ezsp_version or self.ot_rcp_version or self.sdk_version
 
     @classmethod
     def from_json(cls, obj: dict[str, typing.Any]) -> NabuCasaMetadata:
@@ -86,6 +92,9 @@ class NabuCasaMetadata:
         if ezsp_version := obj.pop("ezsp_version", None):
             ezsp_version = AwesomeVersion(ezsp_version)
 
+        if ot_rcp_version := obj.pop("ot_rcp_version", None):
+            ot_rcp_version = AwesomeVersion(ot_rcp_version)
+
         if fw_type := obj.pop("fw_type", None):
             fw_type = FirmwareImageType(fw_type)
 
@@ -96,6 +105,7 @@ class NabuCasaMetadata:
             metadata_version=metadata_version,
             sdk_version=sdk_version,
             ezsp_version=ezsp_version,
+            ot_rcp_version=ot_rcp_version,
             fw_type=fw_type,
         )
 

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -259,3 +259,6 @@ class SpinelProtocol(SerialProtocol):
             ResetReason.BOOTLOADER.serialize(),
             wait_response=False,
         )
+
+        # A small delay is necessary when switching baudrates
+        await asyncio.sleep(0.5)

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -249,9 +249,13 @@ class SpinelProtocol(SerialProtocol):
         prop_id, version_string = PropertyID.deserialize(rsp.data)
         assert prop_id == PropertyID.NCP_VERSION
 
+        # SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455; EFR32; Mar 14 2023 16:03:40
         version = version_string.rstrip(b"\x00").decode("ascii")
 
-        return AwesomeVersion(version)
+        # We strip off the date code to get something reasonably stable
+        short_version, _ = version.split(";", 1)
+
+        return AwesomeVersion(short_version)
 
     async def enter_bootloader(self) -> None:
         await self.send_command(

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import typing
+import asyncio
+import logging
+import dataclasses
+
+import zigpy.types
+import async_timeout
+from awesomeversion import AwesomeVersion
+
+from .common import SerialProtocol, crc16_kermit
+from .spinel_types import CommandID, PropertyID, HDLCSpecial, ResetReason
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class HDLCLiteFrame:
+    data: bytes
+
+    def serialize(self) -> bytes:
+        payload = self.data + crc16_kermit(self.data).to_bytes(2, "little")
+        encoded = bytearray()
+
+        for byte in payload:
+            if byte in (
+                HDLCSpecial.FLAG,
+                HDLCSpecial.ESCAPE,
+                HDLCSpecial.XON,
+                HDLCSpecial.XOFF,
+                HDLCSpecial.VENDOR,
+            ):
+                encoded.append(HDLCSpecial.ESCAPE)
+                byte ^= 0x20
+
+            encoded.append(byte)
+
+        return bytes([HDLCSpecial.FLAG]) + bytes(encoded) + bytes([HDLCSpecial.FLAG])
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> HDLCLiteFrame:
+        unescaped = bytearray()
+        unescaping = False
+
+        for byte in data:
+            if unescaping:
+                byte ^= 0x20
+
+                if byte not in (
+                    HDLCSpecial.FLAG,
+                    HDLCSpecial.ESCAPE,
+                    HDLCSpecial.XON,
+                    HDLCSpecial.XOFF,
+                    HDLCSpecial.VENDOR,
+                ):
+                    raise ValueError(f"Invalid unescaped byte: 0x{byte:02X}")
+
+                unescaping = False
+            elif byte == HDLCSpecial.ESCAPE:
+                unescaping = True
+                continue
+            elif byte == HDLCSpecial.FLAG:
+                continue
+
+            unescaped.append(byte)
+
+        data = unescaped[:-2]
+        crc = unescaped[-2:]
+        computed_crc = crc16_kermit(data).to_bytes(2, "little")
+
+        if computed_crc != crc:
+            raise ValueError(f"Invalid CRC-16: expected {crc!r}, got {computed_crc!r}")
+
+        return cls(data=bytes(data))
+
+
+class SpinelHeader(zigpy.types.Struct):
+    # TODO: allow specifying struct endianness
+    transaction_id: zigpy.types.uint4_t
+    network_link_id: zigpy.types.uint2_t
+    flag: zigpy.types.uint2_t
+
+
+@dataclasses.dataclass(frozen=True)
+class SpinelFrame:
+    header: SpinelHeader
+    command_id: CommandID
+    data: bytes
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> SpinelFrame:
+        orig_data = data
+        header, data = SpinelHeader.deserialize(data)
+
+        if header.flag != 0b10:
+            raise ValueError(f"Spinel header flag is invalid in frame: {orig_data!r}")
+
+        command_id, data = CommandID.deserialize(data)
+
+        return cls(header=header, command_id=command_id, data=data)
+
+    def serialize(self) -> bytes:
+        return self.header.serialize() + self.command_id.serialize() + self.data
+
+
+class SpinelProtocol(SerialProtocol):
+    def __init__(self) -> None:
+        super().__init__()
+        self._transaction_id: int = 1
+        self._pending_frames: dict[int, asyncio.Future] = {}
+
+    def data_received(self, data: bytes) -> None:
+        super().data_received(data)
+
+        self._buffer = self._buffer.lstrip(bytes([HDLCSpecial.FLAG]))
+
+        if bytes([HDLCSpecial.FLAG]) not in self._buffer:
+            return
+
+        while self._buffer:
+            # Flag bytes can come before and after any packet, any number of times
+            chunk, _, self._buffer = self._buffer.partition(bytes([HDLCSpecial.FLAG]))
+
+            if not chunk:
+                continue
+
+            # Decode the HDLC frame
+            try:
+                hdlc_frame = HDLCLiteFrame.from_bytes(chunk)
+            except ValueError:
+                _LOGGER.debug("Failed to decode HDLC chunk %r", chunk)
+                continue
+
+            _LOGGER.debug("Decoded HDLC frame: %r", hdlc_frame)
+
+            # And finally the Spinel frame
+            try:
+                spinel_frame = SpinelFrame.from_bytes(hdlc_frame.data)
+            except ValueError as e:
+                _LOGGER.debug("Failed to decode Spinel frame: %r", e)
+                continue
+
+            self.frame_received(spinel_frame)
+
+    def frame_received(self, frame: SpinelFrame) -> None:
+        _LOGGER.debug("Parsed frame %r", frame)
+
+        if frame.header.transaction_id in self._pending_frames:
+            self._pending_frames[frame.header.transaction_id].set_result(frame)
+
+    @typing.overload
+    async def send_frame(
+        self,
+        frame: SpinelFrame,
+        *,
+        wait_response: typing.Literal[True],
+        retries: int,
+        timeout: float,
+        retry_delay: float,
+    ) -> None:
+        ...
+
+    @typing.overload
+    async def send_frame(
+        self,
+        frame: SpinelFrame,
+        *,
+        wait_response: typing.Literal[False],
+        retries: int,
+        timeout: float,
+        retry_delay: float,
+    ) -> SpinelFrame:
+        ...
+
+    async def send_frame(
+        self,
+        frame: SpinelFrame,
+        *,
+        wait_response: bool = True,
+        retries: int = 3,
+        timeout: float = 1,
+        retry_delay: float = 0.1,
+    ) -> SpinelFrame | None:
+        # A transaction ID of `0` is special: we only use 1-15
+        self._transaction_id = (self._transaction_id + 1) % (0b1111 - 1)
+        tid = 1 + self._transaction_id
+
+        future = asyncio.get_running_loop().create_future()
+        self._pending_frames[tid] = future
+
+        # Replace the transaction ID
+        new_frame = dataclasses.replace(
+            frame, header=frame.header.replace(transaction_id=tid)
+        )
+
+        if not wait_response:
+            _LOGGER.debug("Sending frame %r", new_frame)
+            self.send_data(HDLCLiteFrame(data=new_frame.serialize()).serialize())
+            return None
+
+        try:
+            for attempt in range(retries + 1):
+                _LOGGER.debug("Sending frame %r", new_frame)
+                self.send_data(HDLCLiteFrame(data=new_frame.serialize()).serialize())
+
+                try:
+                    async with async_timeout.timeout(timeout):
+                        return await asyncio.shield(future)
+                except asyncio.TimeoutError:
+                    _LOGGER.debug(
+                        "Failed to send %s, trying again in %0.2fs (attempt %s of %s)",
+                        frame,
+                        retry_delay,
+                        attempt + 1,
+                        retries + 1,
+                    )
+
+                    if attempt >= retries:
+                        raise
+
+                    await asyncio.sleep(retry_delay)
+        finally:
+            del self._pending_frames[tid]
+
+        raise AssertionError("Unreachable")
+
+    async def send_command(
+        self, command_id: CommandID, data: bytes, **kwargs
+    ) -> SpinelFrame:
+        frame = SpinelFrame(
+            header=SpinelHeader(
+                flag=0b10,
+                network_link_id=0,
+                transaction_id=None,
+            ),
+            command_id=command_id,
+            data=data,
+        )
+
+        return await self.send_frame(frame, **kwargs)
+
+    async def probe(self) -> AwesomeVersion:
+        rsp = await self.send_command(
+            CommandID.PROP_VALUE_GET,
+            PropertyID.NCP_VERSION.serialize(),
+        )
+
+        prop_id, version_string = PropertyID.deserialize(rsp.data)
+        assert prop_id == PropertyID.NCP_VERSION
+
+        version = version_string.rstrip(b"\x00").decode("ascii")
+
+        return AwesomeVersion(version)
+
+    async def enter_bootloader(self) -> None:
+        await self.send_command(
+            CommandID.RESET,
+            ResetReason.BOOTLOADER.serialize(),
+            wait_response=False,
+        )

--- a/universal_silabs_flasher/spinel_types.py
+++ b/universal_silabs_flasher/spinel_types.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import enum
+import math
+
+import zigpy.types
+
+
+class PackedUInt21(zigpy.types.uint_t, bits=21):  # type: ignore[call-arg]
+    def serialize(self) -> bytes:
+        n = int(self)
+        chunks = []
+
+        while n:
+            # Set the least significant bit on all other octets.
+            chunks.append((n & 0b01111111) | 0b10000000)
+            n >>= 7
+
+        # Clear the most significant bit of the most significant octet.
+        chunks[-1] &= 0b01111111
+
+        return bytes(chunks)
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> tuple[PackedUInt21, bytes]:
+        chunks = []
+
+        for byte in data:
+            chunks.append(byte & 0b01111111)
+
+            if len(chunks) > math.ceil(cls._bits / 8):
+                raise ValueError(
+                    f"Packed integer cannot be larger than {cls.max_value}"
+                )
+
+            if byte & 0b10000000 == 0:
+                break
+
+        n = 0
+
+        for chunk in chunks[::-1]:
+            n = (n << 7) | chunk
+
+        return cls(n), data[len(chunks) :]
+
+
+class CommandID(PackedUInt21, enum.Enum):
+    NOOP = 0
+    RESET = 1
+    PROP_VALUE_GET = 2
+    PROP_VALUE_SET = 3
+    PROP_VALUE_INSERT = 4
+    PROP_VALUE_REMOVE = 5
+    PROP_VALUE_IS = 6
+    PROP_VALUE_INSERTED = 7
+    PROP_VALUE_REMOVED = 8
+
+    PEEK = 18
+    PEEK_RET = 19
+    POKE = 20
+    PROP_VALUE_MULTI_GET = 21
+    PROP_VALUE_MULTI_SET = 22
+    PROP_VALUES_ARE = 23
+
+    NET_SAVE = 9
+    NET_CLEAR = 10
+    NET_RECALL = 11
+
+    HBO_OFFLOAD = 12
+    HBO_RECLAIM = 13
+    HBO_DROP = 14
+    HBO_OFFLOADED = 15
+    HBO_RECLAIMED = 16
+    HBO_DROPPED = 17
+
+
+class PropertyID(PackedUInt21, enum.Enum):
+    # Core Properties
+    LAST_STATUS = 0
+    PROTOCOL_VERSION = 1
+    NCP_VERSION = 2
+    INTERFACE_TYPE = 3
+    INTERFACE_VENDOR_ID = 4
+    CAPS = 5
+    INTERFACE_COUNT = 6
+    POWER_STATE = 7
+    HWADDR = 8
+    LOCK = 9
+
+    # Host Buffer Offload
+    HBO_MEM_MAX = 10
+    HBO_BLOCK_MAX = 11
+
+    # Stream Properties
+    STREAM_DEBUG = 112
+    STREAM_RAW = 113
+    STREAM_NET = 114
+    # STREAM_NET_INSECURE = 114  # has the same ID as `STREAM_NET`?
+
+    # PHY Properties
+    PHY_ENABLED = 32
+    PHY_CHAN = 33
+    PHY_CHAN_SUPPORTED = 34
+    PHY_FREQ = 35
+    PHY_CCA_THRESHOLD = 36
+    PHY_TX_POWER = 37
+    PHY_RSSI = 38
+    PHY_RX_SENSITIVITY = 39
+
+    # MAC Properties
+    MAC_SCAN_STATE = 38
+    MAC_SCAN_MASK = 49
+    MAC_SCAN_PERIOD = 50
+    MAC_SCAN_BEACON = 51
+    MAC_15_4_LADDR = 52
+    MAC_15_4_SADDR = 53
+    MAC_15_4_PANID = 54
+    MAC_RAW_STREAM_ENABLED = 55
+    MAC_PROMISCUOUS_MODE = 56
+    MAC_ENERGY_SCAN_RESULT = 57
+    MAC_WHITELIST = 4864
+    MAC_WHITELIST_ENABLED = 4865
+
+    # NET Properties
+    NET_SAVED = 64
+    NET_IF_UP = 65
+    NET_STACK_UP = 66
+    NET_ROLE = 67
+    NET_NETWORK_NAME = 68
+    NET_XPANID = 69
+    NET_MASTER_KEY = 70
+    NET_KEY_SEQUENCE_COUNTER = 71
+    NET_PARTITION_ID = 72
+    NET_REQUIRE_JOIN_EXISTING = 73
+    NET_KEY_SWITCH_GUARDTIME = 74
+    NET_PSKC = 75
+
+    # IPv6 Properties
+    IPV6_LL_ADDR = 96
+    IPV6_ML_ADDR = 97
+    IPV6_ML_PREFIX = 98
+    IPV6_ADDRESS_TABLE = 99
+    IPV6_ICMP_PING_OFFLOAD = 101
+
+    # Debug Properties
+    DEBUG_TEST_ASSERT = 16384
+    DEBUG_NCP_LOG_LEVEL = 16385
+
+    # Thread Properties
+    THREAD_LEADER_ADDR = 80
+    THREAD_PARENT = 81
+    THREAD_CHILD_TABLE = 82
+    THREAD_LEADER_RID = 83
+    THREAD_LEADER_WEIGHT = 84
+    THREAD_LOCAL_LEADER_WEIGHT = 85
+    THREAD_NETWORK_DATA = 86
+    THREAD_NETWORK_DATA_VERSION = 87
+    THREAD_STABLE_NETWORK_DATA = 88
+    THREAD_STABLE_NETWORK_DATA_VERSION = 89
+    THREAD_ON_MESH_NETS = 90
+    THREAD_LOCAL_ROUTES = 91
+    THREAD_ASSISTING_PORTS = 92
+    THREAD_ALLOW_LOCAL_NET_DATA_CHANGE = 93
+    THREAD_MODE = 94
+    THREAD_CHILD_TIMEOUT = 5376
+    THREAD_RLOC16 = 5377
+    THREAD_ROUTER_UPGRADE_THRESHOLD = 5378
+    THREAD_CONTEXT_REUSE_DELAY = 5379
+    THREAD_NETWORK_ID_TIMEOUT = 5380
+    THREAD_ACTIVE_ROUTER_IDS = 5381
+    THREAD_RLOC16_DEBUG_PASSTHRU = 5382
+    THREAD_ROUTER_ROLE_ENABLED = 5383
+    THREAD_ROUTER_DOWNGRADE_THRESHOLD = 5384
+    THREAD_ROUTER_SELECTION_JITTER = 5385
+    THREAD_PREFERRED_ROUTER_ID = 5386
+    THREAD_NEIGHBOR_TABLE = 5387
+    THREAD_CHILD_COUNT_MAX = 5388
+    THREAD_LEADER_NETWORK_DATA = 5389
+    THREAD_STABLE_LEADER_NETWORK_DATA = 5390
+    THREAD_JOINERS = 5391
+    THREAD_COMMISSIONER_ENABLED = 5392
+    THREAD_BA_PROXY_ENABLED = 5393
+    THREAD_BA_PROXY_STREAM = 5394
+    THREAD_DISOVERY_SCAN_JOINER_FLAG = 5395
+    THREAD_DISCOVERY_SCAN_ENABLE_FILTERING = 5396
+    THREAD_DISCOVERY_SCAN_PANID = 5397
+    THREAD_STEERING_DATA = 5398
+
+    # Jam detection
+    JAM_DETECT_ENABLE = 4608
+    JAM_DETECTED = 4609
+    JAM_DETECT_RSSI_THRESHOLD = 4610
+    JAM_DETECT_WINDOW = 4611
+    JAM_DETECT_BUSY = 4612
+    JAM_DETECT_HISTORY_BITMAP = 4613
+
+    # GPIO
+    GPIO_CONFIG = 4096
+    GPIO_STATE = 4098
+    GPIO_STATE_SET = 4099
+    GPIO_STATE_CLEAR = 4100
+
+    # True random number generation
+    TRNG_32 = 4101
+    TRNG_128 = 4102
+    TRNG_RAW_32 = 4103
+
+
+class ResetReason(zigpy.types.enum8):
+    PLATFORM = 1
+    STACK = 2
+    BOOTLOADER = 3
+
+
+class HDLCSpecial(enum.IntEnum):
+    FLAG = 0x7E
+    ESCAPE = 0x7D
+    XON = 0x11
+    XOFF = 0x13
+    VENDOR = 0xF8


### PR DESCRIPTION
Depends on a few patches to OpenThread to work:

 - https://github.com/puddly/openthread/tree/puddly/reboot-bootloader
 - https://github.com/puddly/ot-efr32/tree/puddly/bootloader-reboot

One notable problem is that OpenThread doesn't have version numbers:

```
Detected ApplicationType.SPINEL, version OPENTHREAD/6ff1ac0-dirty; EFR32; Dec 23 2022 18:08:00
```

One possible solution would be to transform the version into something more parsable, like:

```
2022.12.23-180800-OPENTHREAD/6ff1ac0-dirty
```

Alternatively, we can just ignore all version number parsing and always flash firmware if the version number differs.