### PR TITLE
Fix startup when flashing GBL without metadata

### DIFF
--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -225,7 +225,8 @@ async def flash(
 
     # Prefer to probe the expected firmware image type first, if it is known
     if (
-        metadata.fw_type is not None
+        metadata is not None
+        and metadata.fw_type is not None
         and ctx.parent.get_parameter_source("probe_method")
         == click.core.ParameterSource.DEFAULT
     ):

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -71,7 +71,7 @@ class ApplicationType(enum.Enum):
 
 
 FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
-    FirmwareImageType.NCP_UART_HW: ApplicationType.GECKO_BOOTLOADER,
+    FirmwareImageType.NCP_UART_HW: ApplicationType.EZSP,
     FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
     FirmwareImageType.ZIGBEE_NCP_RCP_UART_802154: ApplicationType.CPC,
     FirmwareImageType.OT_RCP: ApplicationType.SPINEL,


### PR DESCRIPTION
Fixes #21.

Startup fails when a GBL file is passed without metadata. This also fixes double probing the bootloader, as an incorrect firmware type to application type mapping was introduced in the Spinel PR.