### PR TITLE
Support multiple baudrates for the same firmware when probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ Usage: universal-silabs-flasher [OPTIONS] COMMAND [ARGS]...
 Options:
   -v, --verbose
   --device PATH_OR_URL           [required]
-  --baudrate INTEGER             [default: 115200]
-  --bootloader-baudrate INTEGER  [default: 115200]
-  --cpc-baudrate INTEGER         [default: 115200, 460800]
-  --ezsp-baudrate INTEGER        [default: 115200]
-  --spinel-baudrate INTEGER      [default: 460800]
+  --bootloader-baudrate NUMBERS  [default: 115200]
+  --cpc-baudrate NUMBERS         [default: 460800, 115200, 230400]
+  --ezsp-baudrate NUMBERS        [default: 115200]
+  --spinel-baudrate NUMBERS      [default: 460800]
   --probe-method TEXT            [default: bootloader, cpc, ezsp, spinel]
   --help                         Show this message and exit.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Options:
   --device PATH_OR_URL           [required]
   --baudrate INTEGER             [default: 115200]
   --bootloader-baudrate INTEGER  [default: 115200]
-  --cpc-baudrate INTEGER         [default: 460800,115200]
+  --cpc-baudrate INTEGER         [default: 115200, 460800]
   --ezsp-baudrate INTEGER        [default: 115200]
   --spinel-baudrate INTEGER      [default: 460800]
   --probe-method TEXT            [default: bootloader, cpc, ezsp, spinel]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Options:
   --device PATH_OR_URL           [required]
   --baudrate INTEGER             [default: 115200]
   --bootloader-baudrate INTEGER  [default: 115200]
-  --cpc-baudrate INTEGER         [default: 115200]
+  --cpc-baudrate INTEGER         [default: 460800,115200]
   --ezsp-baudrate INTEGER        [default: 115200]
   --spinel-baudrate INTEGER      [default: 460800]
   --probe-method TEXT            [default: bootloader, cpc, ezsp, spinel]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from universal_silabs_flasher.common import StateMachine
+from universal_silabs_flasher.common import StateMachine, put_first
 
 
 async def test_state_machine_bad_initial_state():
@@ -27,3 +27,10 @@ async def test_state_machine():
     await asyncio.gather(sm.wait_for_state("a"), sm.wait_for_state("a"))
 
     assert sm.state == "a"
+
+
+def test_put_first():
+    assert put_first([1, 2, 3], [2]) == [2, 1, 3]
+    assert put_first([1, 2, 3], [4]) == [4, 1, 2, 3]
+    assert put_first([1, 2, 3], [1]) == [1, 2, 3]
+    assert put_first([1, 2, 3], [3]) == [3, 1, 2]

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -196,3 +196,8 @@ class CommaSeparatedNumbers(click.ParamType):
                 )
 
         return values
+
+
+def put_first(lst: list[typing.Any], elements: list[typing.Any]) -> list[typing.Any]:
+    """Orders a list so that the provided element is first."""
+    return elements + [e for e in lst if e not in elements]

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -176,8 +176,10 @@ async def connect_protocol(port, baudrate, factory):
         await asyncio.sleep(0)
 
 
-class CommaSeparatedNumbers(click.Option):
+class CommaSeparatedNumbers(click.ParamType):
     """Click type to parse comma-separated numbers into a list of integers."""
+
+    name = "numbers"
 
     def type_cast_value(self, ctx: click.Context, value: str) -> list[int]:
         values = []

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -7,6 +7,7 @@ import contextlib
 import collections
 
 import crc
+import click
 import zigpy.serial
 import async_timeout
 import serial_asyncio
@@ -173,3 +174,23 @@ async def connect_protocol(port, baudrate, factory):
 
         # Required for Windows to be able to re-connect to the same serial port
         await asyncio.sleep(0)
+
+
+class CommaSeparatedNumbers(click.Option):
+    """Click type to parse comma-separated numbers into a list of integers."""
+
+    def type_cast_value(self, ctx: click.Context, value: str) -> list[int]:
+        values = []
+
+        for v in value.split(","):
+            if not v.strip():
+                continue
+
+            try:
+                values.append(int(v, 10))
+            except ValueError:
+                raise click.BadParameter(
+                    f"Comma-separated list of numbers contains bad value: {v!r}"
+                )
+
+        return values

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -1,0 +1,38 @@
+import enum
+
+
+class FirmwareImageType(enum.Enum):
+    # EmberZNet Zigbee firmware
+    NCP_UART_HW = "ncp-uart-hw"
+
+    # Multi-PAN RCP Multiprotocol (via zigbeed)
+    RCP_UART_802154 = "rcp-uart-802154"
+
+    # Zigbee NCP + OpenThread RCP
+    ZIGBEE_NCP_RCP_UART_802154 = "zigbee-ncp-rcp-uart-802154"
+
+    # OpenThread RCP
+    OT_RCP = "ot-rcp"
+
+
+class ApplicationType(enum.Enum):
+    GECKO_BOOTLOADER = "bootloader"
+    CPC = "cpc"
+    EZSP = "ezsp"
+    SPINEL = "spinel"
+
+
+FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
+    FirmwareImageType.NCP_UART_HW: ApplicationType.EZSP,
+    FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
+    FirmwareImageType.ZIGBEE_NCP_RCP_UART_802154: ApplicationType.CPC,
+    FirmwareImageType.OT_RCP: ApplicationType.SPINEL,
+}
+
+
+DEFAULT_BAUDRATES = {
+    ApplicationType.GECKO_BOOTLOADER: [115200],
+    ApplicationType.CPC: [460800, 115200, 230400],
+    ApplicationType.EZSP: [115200],
+    ApplicationType.SPINEL: [460800],
+}

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -17,13 +17,9 @@ import bellows.types
 import zigpy.ota.validators
 
 from .gbl import GBLImage, FirmwareImageType
+from .const import DEFAULT_BAUDRATES, FW_IMAGE_TYPE_TO_APPLICATION_TYPE, ApplicationType
 from .common import CommaSeparatedNumbers, patch_pyserial_asyncio
-from .flasher import (
-    DEFAULT_BAUDRATES,
-    FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
-    Flasher,
-    ApplicationType,
-)
+from .flasher import Flasher
 from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE, ReceiverCancelled
 
 patch_pyserial_asyncio()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -17,7 +17,7 @@ import bellows.types
 import zigpy.ota.validators
 
 from .gbl import GBLImage, FirmwareImageType
-from .common import patch_pyserial_asyncio
+from .common import CommaSeparatedNumbers, patch_pyserial_asyncio
 from .flasher import (
     DEFAULT_BAUDRATES,
     FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
@@ -108,26 +108,31 @@ class SerialPort(click.ParamType):
 @click.option(
     "--baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.CPC],
+    type=CommaSeparatedNumbers(),
     show_default=True,
 )
 @click.option(
     "--bootloader-baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
+    type=CommaSeparatedNumbers(),
     show_default=True,
 )
 @click.option(
     "--cpc-baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.CPC],
+    type=CommaSeparatedNumbers(),
     show_default=True,
 )
 @click.option(
     "--ezsp-baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.EZSP],
+    type=CommaSeparatedNumbers(),
     show_default=True,
 )
 @click.option(
     "--spinel-baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.SPINEL],
+    type=CommaSeparatedNumbers(),
     show_default=True,
 )
 @click.option(

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -105,12 +105,7 @@ class SerialPort(click.ParamType):
 @click.group()
 @click.option("-v", "--verbose", count=True)
 @click.option("--device", type=SerialPort(), required=True)
-@click.option(
-    "--baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.CPC],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-)
+@click.option("--baudrate", hidden=True)
 @click.option(
     "--bootloader-baudrate",
     default=DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
@@ -158,9 +153,11 @@ def main(
 
     # Override all application baudrates if a specific value is provided
     if ctx.get_parameter_source("baudrate") != click.core.ParameterSource.DEFAULT:
-        cpc_baudrate = baudrate
-        ezsp_baudrate = baudrate
-        spinel_baudrate = baudrate
+        raise click.ClickException(
+            "The `--baudrate` flag is deprecated. Remove it to rely on auto baudrate"
+            " probing, or replace it with an application-specific baudrate flag"
+            " (see `--help`)"
+        )
 
     ctx.obj = {
         "verbosity": verbose,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -80,7 +80,7 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
 
 DEFAULT_BAUDRATES = {
     ApplicationType.GECKO_BOOTLOADER: [115200],
-    ApplicationType.CPC: [115200, 460800],
+    ApplicationType.CPC: [460800, 115200, 230400],
     ApplicationType.EZSP: [115200],
     ApplicationType.SPINEL: [460800],
 }

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import time
 import typing
 import asyncio
@@ -14,7 +13,8 @@ import bellows.config
 from awesomeversion import AwesomeVersion
 
 from .cpc import CPCProtocol
-from .gbl import GBLImage, FirmwareImageType
+from .gbl import GBLImage
+from .const import DEFAULT_BAUDRATES, ApplicationType
 from .common import PROBE_TIMEOUT, connect_protocol
 from .spinel import SpinelProtocol
 from .emberznet import connect_ezsp
@@ -61,29 +61,6 @@ async def send_gpio_pattern(
     await asyncio.get_running_loop().run_in_executor(
         None, _send_gpio_pattern, pin_states, toggle_delay
     )
-
-
-class ApplicationType(enum.Enum):
-    GECKO_BOOTLOADER = "bootloader"
-    CPC = "cpc"
-    EZSP = "ezsp"
-    SPINEL = "spinel"
-
-
-FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
-    FirmwareImageType.NCP_UART_HW: ApplicationType.EZSP,
-    FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
-    FirmwareImageType.ZIGBEE_NCP_RCP_UART_802154: ApplicationType.CPC,
-    FirmwareImageType.OT_RCP: ApplicationType.SPINEL,
-}
-
-
-DEFAULT_BAUDRATES = {
-    ApplicationType.GECKO_BOOTLOADER: [115200],
-    ApplicationType.CPC: [460800, 115200, 230400],
-    ApplicationType.EZSP: [115200],
-    ApplicationType.SPINEL: [460800],
-}
 
 
 @dataclasses.dataclass(frozen=True)

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import json
 import typing
 import logging
@@ -9,6 +8,7 @@ import dataclasses
 from awesomeversion import AwesomeVersion
 from zigpy.ota.validators import parse_silabs_gbl
 
+from .const import FirmwareImageType
 from .cpc_types import enum32
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,20 +47,6 @@ class TagId(enum32):
     # End of the GBL file. It contains a 32-bit CRC for the entire file as an integrity
     # check. The CRC is a non-cryptographic check. This must be the last tag.
     END = 0xFC0404FC
-
-
-class FirmwareImageType(enum.Enum):
-    # EmberZNet Zigbee firmware
-    NCP_UART_HW = "ncp-uart-hw"
-
-    # Multi-PAN RCP Multiprotocol (via zigbeed)
-    RCP_UART_802154 = "rcp-uart-802154"
-
-    # Zigbee NCP + OpenThread RCP
-    ZIGBEE_NCP_RCP_UART_802154 = "zigbee-ncp-rcp-uart-802154"
-
-    # OpenThread RCP
-    OT_RCP = "ot-rcp"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -58,6 +58,7 @@ class NabuCasaMetadata:
     ot_rcp_version: AwesomeVersion | None
 
     fw_type: FirmwareImageType | None
+    baudrate: int | None
 
     def get_public_version(self) -> AwesomeVersion | None:
         return self.ezsp_version or self.ot_rcp_version or self.sdk_version
@@ -84,6 +85,8 @@ class NabuCasaMetadata:
         if fw_type := obj.pop("fw_type", None):
             fw_type = FirmwareImageType(fw_type)
 
+        baudrate = obj.pop("baudrate", None)
+
         if obj:
             _LOGGER.warning("Unexpected keys in JSON remain: %r", obj)
 
@@ -93,6 +96,7 @@ class NabuCasaMetadata:
             ezsp_version=ezsp_version,
             ot_rcp_version=ot_rcp_version,
             fw_type=fw_type,
+            baudrate=baudrate,
         )
 
 


### PR DESCRIPTION
Allows multiple baudrates to be specified when probing via `--cpc-baudrate 115200,460800`. The defaults already include these.