### PR TITLE
Version prefix matching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -26,7 +26,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.1.1
     hooks:
       - id: mypy
 
@@ -36,6 +36,6 @@ repos:
       - id: pyupgrade
 
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.1
+    rev: v2.0.2
     hooks:
       - id: autoflake

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ install_requires =
     gpiod; platform_system=="Linux"
     coloredlogs
     async_timeout
-    awesomeversion
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     gpiod; platform_system=="Linux"
     coloredlogs
     async_timeout
+    typing_extensions
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from universal_silabs_flasher.common import StateMachine, put_first
+from universal_silabs_flasher.common import Version, StateMachine, put_first
 
 
 async def test_state_machine_bad_initial_state():
@@ -34,3 +34,51 @@ def test_put_first():
     assert put_first([1, 2, 3], [4]) == [4, 1, 2, 3]
     assert put_first([1, 2, 3], [1]) == [1, 2, 3]
     assert put_first([1, 2, 3], [3]) == [3, 1, 2]
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "2.00.01",
+        "7.2.2.0 build 190",
+        "4.2.2",
+        "SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455",
+    ],
+)
+def test_version_parsing(version):
+    v1 = Version(version)
+    v2 = Version(version)
+
+    assert v1.compatible_with(v2)
+    assert v1 == v2
+    assert v1 >= v2
+    assert not v1 > v2
+
+
+def test_version_comparison_simple():
+    assert Version("2.00.01") > Version("2.00.00")
+    assert Version("2.10.01") > Version("2.00.02")
+    assert Version("2.00.01") >= Version("2.00.00")
+    assert Version("2.00.01") != Version("2.00.00")
+
+
+def test_version_comparison_thread():
+    assert Version("SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455").compatible_with(
+        Version("SL-OPENTHREAD/2.2.2.0_GitHub-asdfoo")
+    )
+
+    assert not Version("SL-OPENTHREAD/2.2.2.1_GitHub-91fa1f455").compatible_with(
+        Version("SL-OPENTHREAD/2.2.2.0_GitHub-asdfoo")
+    )
+
+    assert Version("SL-OPENTHREAD/2.2.2.1_GitHub-91fa1f455") > Version(
+        "SL-OPENTHREAD/2.2.2.0_GitHub-asdfoo"
+    )
+
+
+def test_version_comparison_ezsp():
+    assert Version("7.2.2.0 build 191") > Version("7.2.2.0 build 190")
+    assert Version("7.2.2.0").compatible_with(Version("7.2.2.0 build 190"))
+    assert not Version("7.2.2.0 build 191").compatible_with(
+        Version("7.2.2.0 build 190")
+    )

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -13,6 +13,12 @@ import zigpy.serial
 import async_timeout
 import serial_asyncio
 
+if typing.TYPE_CHECKING:
+    try:
+        from typing import Self
+    except ImportError:
+        from typing_extensions import Self
+
 _LOGGER = logging.getLogger(__name__)
 
 CONNECT_TIMEOUT = 1
@@ -215,7 +221,7 @@ class Version:
     incomparable: str | None = dataclasses.field(compare=False, default=None)
 
     @classmethod
-    def from_string(cls: type[typing.Self], version: str) -> typing.Self:
+    def from_string(cls: type[Self], version: str) -> Self:
         comparable, _, incomparable = version.partition(":")
 
         return cls(
@@ -231,6 +237,6 @@ class Version:
 
         return repr(version)
 
-    def compatible_with(self, other: typing.Self) -> bool:
+    def compatible_with(self, other: Self) -> bool:
         prefix_length = min(len(self.comparable), len(other.comparable))
         return self.comparable[:prefix_length] == other.comparable[:prefix_length]

--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -249,7 +249,7 @@ class CPCProtocol(SerialProtocol):
         patch, version_bytes = zigpy.types.uint32_t.deserialize(version_bytes)
         assert not version_bytes
 
-        return Version.from_string(f"{major}.{minor}.{patch}")
+        return Version(f"{major}.{minor}.{patch}")
 
     async def get_secondary_version(self) -> Version:
         """Read the secondary app version from the device."""

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -15,7 +15,6 @@ import coloredlogs
 import zigpy.types
 import bellows.types
 import zigpy.ota.validators
-from awesomeversion.exceptions import AwesomeVersionCompareException
 
 from .gbl import GBLImage, FirmwareImageType
 from .const import DEFAULT_BAUDRATES, FW_IMAGE_TYPE_TO_APPLICATION_TYPE, ApplicationType
@@ -270,18 +269,11 @@ async def flash(
         app_version = flasher.app_version
         fw_version = metadata.get_public_version()
 
-        try:
-            app_version > fw_version  # noqa: B015
-        except AwesomeVersionCompareException:
-            can_compare_versions = False
-        else:
-            can_compare_versions = True
-
         is_cross_flashing = (
             metadata.fw_type is not None
             and running_image_type is not None
             and metadata.fw_type != running_image_type
-        ) or not can_compare_versions
+        )
 
         if is_cross_flashing and not allow_cross_flashing:
             raise click.ClickException(
@@ -291,12 +283,12 @@ async def flash(
             )
 
         if not is_cross_flashing:
-            if app_version == fw_version:
+            if app_version.compatible_with(fw_version):
                 _LOGGER.info(
                     "Firmware version %s is flashed, not re-installing", app_version
                 )
                 return
-            elif ensure_exact_version and app_version != fw_version:
+            elif ensure_exact_version and not app_version.compatible_with(fw_version):
                 _LOGGER.info(
                     "Firmware version %s does not match expected version %s",
                     fw_version,

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -301,6 +301,10 @@ async def flash(
                     app_version,
                 )
                 return
+        else:
+            _LOGGER.info(
+                "Cross-flashing from %s to %s", running_image_type, metadata.fw_type
+            )
 
     await flasher.enter_bootloader()
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -150,7 +150,7 @@ class Flasher:
             _, _, version = await ezsp.get_board_info()
 
         return ProbeResult(
-            version=Version.from_string(version.replace(" build ", ".")),
+            version=Version(version),
             baudrate=baudrate,
             continue_probing=False,
         )

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -92,6 +92,8 @@ class Flasher:
         self.bootloader_baudrate: int | None = None
 
     async def enter_yellow_bootloader(self):
+        _LOGGER.info("Triggering Yellow bootloader")
+
         await send_gpio_pattern(
             pin_states={
                 24: [True, False, False],

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -5,10 +5,10 @@ import typing
 import logging
 import dataclasses
 
-from awesomeversion import AwesomeVersion
 from zigpy.ota.validators import parse_silabs_gbl
 
 from .const import FirmwareImageType
+from .common import Version
 from .cpc_types import enum32
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,14 +53,14 @@ class TagId(enum32):
 class NabuCasaMetadata:
     metadata_version: int
 
-    sdk_version: AwesomeVersion | None
-    ezsp_version: AwesomeVersion | None
-    ot_rcp_version: AwesomeVersion | None
+    sdk_version: Version | None
+    ezsp_version: Version | None
+    ot_rcp_version: Version | None
 
     fw_type: FirmwareImageType | None
     baudrate: int | None
 
-    def get_public_version(self) -> AwesomeVersion | None:
+    def get_public_version(self) -> Version | None:
         return self.ezsp_version or self.ot_rcp_version or self.sdk_version
 
     @classmethod
@@ -74,13 +74,13 @@ class NabuCasaMetadata:
             )
 
         if sdk_version := obj.pop("sdk_version", None):
-            sdk_version = AwesomeVersion(sdk_version)
+            sdk_version = Version.from_string(sdk_version)
 
         if ezsp_version := obj.pop("ezsp_version", None):
-            ezsp_version = AwesomeVersion(ezsp_version)
+            ezsp_version = Version.from_string(ezsp_version)
 
         if ot_rcp_version := obj.pop("ot_rcp_version", None):
-            ot_rcp_version = AwesomeVersion(ot_rcp_version)
+            ot_rcp_version = Version.from_string(ot_rcp_version)
 
         if fw_type := obj.pop("fw_type", None):
             fw_type = FirmwareImageType(fw_type)

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -74,13 +74,13 @@ class NabuCasaMetadata:
             )
 
         if sdk_version := obj.pop("sdk_version", None):
-            sdk_version = Version.from_string(sdk_version)
+            sdk_version = Version(sdk_version)
 
         if ezsp_version := obj.pop("ezsp_version", None):
-            ezsp_version = Version.from_string(ezsp_version)
+            ezsp_version = Version(ezsp_version)
 
         if ot_rcp_version := obj.pop("ot_rcp_version", None):
-            ot_rcp_version = Version.from_string(ot_rcp_version)
+            ot_rcp_version = Version(ot_rcp_version)
 
         if fw_type := obj.pop("fw_type", None):
             fw_type = FirmwareImageType(fw_type)

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -7,9 +7,8 @@ import asyncio
 import logging
 
 import async_timeout
-from awesomeversion import AwesomeVersion
 
-from .common import PROBE_TIMEOUT, StateMachine, SerialProtocol
+from .common import PROBE_TIMEOUT, Version, StateMachine, SerialProtocol
 from .xmodemcrc import send_xmodem128_crc
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,12 +64,12 @@ class GeckoBootloaderProtocol(SerialProtocol):
         self._version: str | None = None
         self._upload_status: str | None = None
 
-    async def probe(self) -> AwesomeVersion:
+    async def probe(self) -> Version:
         """Attempt to communicate with the bootloader."""
         async with async_timeout.timeout(PROBE_TIMEOUT):
             return await self.ebl_info()
 
-    async def ebl_info(self) -> AwesomeVersion:
+    async def ebl_info(self) -> Version:
         """Select `ebl info` in the menu and return the bootloader version."""
         self._state_machine.state = State.WAITING_FOR_MENU
         self.send_data(GeckoBootloaderOption.EBL_INFO)
@@ -78,7 +77,7 @@ class GeckoBootloaderProtocol(SerialProtocol):
         await self._state_machine.wait_for_state(State.IN_MENU)
 
         assert self._version is not None
-        return AwesomeVersion(self._version)
+        return Version.from_string(self._version)
 
     async def run_firmware(self) -> None:
         """Select `run` in the menu."""

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -77,7 +77,7 @@ class GeckoBootloaderProtocol(SerialProtocol):
         await self._state_machine.wait_for_state(State.IN_MENU)
 
         assert self._version is not None
-        return Version.from_string(self._version)
+        return Version(self._version)
 
     async def run_firmware(self) -> None:
         """Select `run` in the menu."""

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -254,7 +254,7 @@ class SpinelProtocol(SerialProtocol):
         # We strip off the date code to get something reasonably stable
         short_version, _ = version.split(";", 1)
 
-        return Version.from_string(short_version)
+        return Version(short_version)
 
     async def enter_bootloader(self) -> None:
         await self.send_command(

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -7,9 +7,8 @@ import dataclasses
 
 import zigpy.types
 import async_timeout
-from awesomeversion import AwesomeVersion
 
-from .common import SerialProtocol, crc16_kermit
+from .common import Version, SerialProtocol, crc16_kermit
 from .spinel_types import CommandID, PropertyID, HDLCSpecial, ResetReason
 
 _LOGGER = logging.getLogger(__name__)
@@ -240,7 +239,7 @@ class SpinelProtocol(SerialProtocol):
 
         return await self.send_frame(frame, **kwargs)
 
-    async def probe(self) -> AwesomeVersion:
+    async def probe(self) -> Version:
         rsp = await self.send_command(
             CommandID.PROP_VALUE_GET,
             PropertyID.NCP_VERSION.serialize(),
@@ -255,7 +254,7 @@ class SpinelProtocol(SerialProtocol):
         # We strip off the date code to get something reasonably stable
         short_version, _ = version.split(";", 1)
 
-        return AwesomeVersion(short_version)
+        return Version.from_string(short_version)
 
     async def enter_bootloader(self) -> None:
         await self.send_command(


### PR DESCRIPTION
Version matching with EmberZNet currently fails due to a length mismatch between the firmware version and the GBL version. For example, `7.2.2.0 build 123` is converted into `7.2.2.0.123`, but the GBL only includes `7.2.2.0`, which causes the matching to fail.

I've replaced AwesomeVersion with a simpler solution that matches based on the shortest prefix, so the `.123` part will be ignored.