### PR TITLE
Reflash when expected baudrate differs from detected baudrate

### DIFF
--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -283,7 +283,16 @@ async def flash(
             )
 
         if not is_cross_flashing:
-            if app_version.compatible_with(fw_version):
+            if (
+                metadata.baudrate is not None
+                and metadata.baudrate != flasher.app_baudrate
+            ):
+                _LOGGER.info(
+                    "Firmware baudrate %s differs from expected baudrate %s",
+                    flasher.app_baudrate,
+                    metadata.baudrate,
+                )
+            elif app_version.compatible_with(fw_version):
                 _LOGGER.info(
                     "Firmware version %s is flashed, not re-installing", app_version
                 )


### PR DESCRIPTION
Useful for when firmware version numbers and commit hashes don't change but the baudrate was increased.