### PR TITLE
Sonoff ZBDongle-E Reset

### DIFF
--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -190,6 +190,7 @@ async def write_ieee(ctx, ieee):
 @click.option("--allow-downgrades", is_flag=True, default=False, show_default=True)
 @click.option("--allow-cross-flashing", is_flag=True, default=False, show_default=True)
 @click.option("--yellow-gpio-reset", is_flag=True, default=False, show_default=True)
+@click.option("--sonoff-reset", is_flag=True, default=False, show_default=True)
 @click.pass_context
 @click_coroutine
 async def flash(
@@ -200,6 +201,7 @@ async def flash(
     allow_downgrades,
     allow_cross_flashing,
     yellow_gpio_reset,
+    sonoff_reset,
 ):
     flasher = ctx.obj["flasher"]
 
@@ -248,7 +250,7 @@ async def flash(
             )
 
     try:
-        await flasher.probe_app_type(yellow_gpio_reset=yellow_gpio_reset)
+        await flasher.probe_app_type(yellow_gpio_reset=yellow_gpio_reset, sonoff_reset=sonoff_reset)
     except RuntimeError as e:
         raise click.ClickException(str(e)) from e
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -138,6 +138,7 @@ class Flasher:
 
                 if run_firmware:
                     await gecko.run_firmware()
+                    _LOGGER.info("Launched application from bootloader")
         except NoFirmwareError:
             _LOGGER.warning("No application can be launched")
             return ProbeResult(
@@ -235,13 +236,6 @@ class Flasher:
                 _LOGGER.info("Detected bootloader version %s", result.version)
                 bootloader_probe = result
                 self.bootloader_baudrate = bootloader_probe.baudrate
-
-                # We cannot assume that the bootloader is the only running application
-                # if we did not try to start an application
-                if only_probe_bootloader:
-                    break
-
-                _LOGGER.info("Launched application from bootloader, continuing probing")
 
             if result.continue_probing:
                 continue

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -11,6 +11,7 @@ import async_timeout
 import bellows.types
 import bellows.config
 
+from .common import SerialProtocol
 from .cpc import CPCProtocol
 from .gbl import GBLImage
 from .const import DEFAULT_BAUDRATES, ApplicationType
@@ -102,6 +103,20 @@ class Flasher:
             toggle_delay=0.1,
         )
 
+    async def enter_sonoff_bootloader(self):
+        _LOGGER.info("Triggering Sonoff bootloader")
+
+        baudrate = self._baudrates[ApplicationType.GECKO_BOOTLOADER][0]
+        async with connect_protocol(self._device, baudrate, SerialProtocol) as sonoff:
+            serial = sonoff._transport.serial
+            serial.dtr = False
+            serial.rts = True
+            await asyncio.sleep(0.1)
+            serial.dtr = True
+            serial.rts = False
+            await asyncio.sleep(0.5)
+            serial.dtr = False
+
     def _connect_gecko_bootloader(self, baudrate: int):
         return connect_protocol(self._device, baudrate, GeckoBootloaderProtocol)
 
@@ -172,12 +187,15 @@ class Flasher:
         types: typing.Iterable[ApplicationType] | None = None,
         *,
         yellow_gpio_reset: bool = False,
+        sonoff_reset: bool = False,
     ) -> None:
         if types is None:
             types = self._probe_methods
 
         if yellow_gpio_reset:
             await self.enter_yellow_bootloader()
+        elif sonoff_reset:
+            await self.enter_sonoff_bootloader()
 
         bootloader_probe = None
 
@@ -233,22 +251,20 @@ class Flasher:
             self.app_baudrate = result.baudrate
             break
         else:
-            if bootloader_probe is None:
+            if bootloader_probe and (yellow_gpio_reset or sonoff_reset):
+                # We have no valid application image but can still reenter the bootloader
+                if yellow_gpio_reset:
+                    await self.enter_yellow_bootloader()
+                elif sonoff_reset:
+                    await self.enter_sonoff_bootloader()
+
+                self.app_type = ApplicationType.GECKO_BOOTLOADER
+                self.app_version = bootloader_probe.version
+                self.app_baudrate = bootloader_probe.baudrate
+                self.bootloader_baudrate = bootloader_probe.baudrate
+                _LOGGER.warning("Bootloader did not launch a valid application")
+            else:
                 raise RuntimeError("Failed to probe running application type")
-            elif not yellow_gpio_reset and only_probe_bootloader:
-                raise RuntimeError(
-                    "Cannot reboot back into bootloader from unknown application"
-                )
-
-            # We have no valid application image but can still enter the bootloader
-            if yellow_gpio_reset:
-                await self.enter_yellow_bootloader()
-
-            self.app_type = ApplicationType.GECKO_BOOTLOADER
-            self.app_version = bootloader_probe.version
-            self.app_baudrate = bootloader_probe.baudrate
-            self.bootloader_baudrate = bootloader_probe.baudrate
-            _LOGGER.warning("Bootloader did not launch a valid application")
 
         _LOGGER.info(
             "Detected %s, version %s at %s baudrate (bootloader baudrate %s)",


### PR DESCRIPTION
This implements the reset capability on ZBDongle-E via RTS/DTR lines as mentioned in #27.

Tested on a dongle I have here and is working reliably. Naming of the flag reflects the fact I am not aware of any other Silabs devices that support this reset method (although it does seem to be somewhat common on TI dongles).

The second commit fixes a bug when running with `--probe-method bootloader` either with a reset flag or with a device that was manually placed into bootloader mode prior to running, which fails to flash anything due to app_type being None.

This also allows flashing a ZBDongle-E that is running the router firmware. Something that is otherwise not possible with the current release as there is no probe for that app firmware.