### PR TITLE
Add a command to extract GBL metadata JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Options:
   --help                         Show this message and exit.
 
 Commands:
+  dump-gbl-metadata
   flash
   write-ieee
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ check_untyped_defs = true
 show_error_codes = true
 show_error_context = true
 disable_error_code = [
-	"union-attr",
 	"attr-defined",
 	"arg-type",
 ]

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -129,6 +129,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def send_data(self, data: bytes) -> None:
         """Sends data over the connected transport."""
+        assert self._transport is not None
         data = bytes(data)
         _LOGGER.debug("Sending data %s", data)
         self._transport.write(data)

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -43,7 +43,7 @@ def click_enum_validator_factory(
     """Click enum validator factory."""
 
     def validator_callback(
-        ctx: click.Context, param: typing.Any, value: typing.Any
+        ctx: click.Context, param: click.Parameter, value: tuple[str]
     ) -> typing.Any:
         values = []
 
@@ -66,7 +66,7 @@ class SerialPort(click.ParamType):
 
     name = "path_or_url"
 
-    def convert(self, value, param, ctx):
+    def convert(self, value: tuple | str, param: click.Parameter, ctx: click.Context):
         if isinstance(value, tuple):
             return value
 
@@ -136,16 +136,16 @@ class SerialPort(click.ParamType):
 )
 @click.pass_context
 def main(
-    ctx,
-    verbose,
-    device,
-    baudrate,
-    bootloader_baudrate,
-    cpc_baudrate,
-    ezsp_baudrate,
-    spinel_baudrate,
-    probe_method,
-):
+    ctx: click.Context,
+    verbose: bool,
+    device: str,
+    baudrate: int | None,
+    bootloader_baudrate: list[int],
+    cpc_baudrate: list[int],
+    ezsp_baudrate: list[int],
+    spinel_baudrate: list[int],
+    probe_method: list[ApplicationType],
+) -> None:
     coloredlogs.install(level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, verbose)])
 
     # Override all application baudrates if a specific value is provided
@@ -223,7 +223,7 @@ async def dump_gbl_metadata(ctx: click.Context, firmware: typing.BinaryIO) -> No
 @click.pass_context
 @click.option("--ieee", required=True, type=zigpy.types.EUI64.convert)
 @click_coroutine
-async def write_ieee(ctx, ieee):
+async def write_ieee(ctx: click.Context, ieee: zigpy.types.EUI64) -> None:
     new_eui64 = bellows.types.EmberEUI64(ieee)
 
     try:
@@ -243,15 +243,15 @@ async def write_ieee(ctx, ieee):
 @click.pass_context
 @click_coroutine
 async def flash(
-    ctx,
-    firmware,
-    force,
-    ensure_exact_version,
-    allow_downgrades,
-    allow_cross_flashing,
-    yellow_gpio_reset,
-    sonoff_reset,
-):
+    ctx: click.Context,
+    firmware: typing.BinaryIO,
+    force: bool,
+    ensure_exact_version: bool,
+    allow_downgrades: bool,
+    allow_cross_flashing: bool,
+    yellow_gpio_reset: bool,
+    sonoff_reset: bool,
+) -> None:
     flasher = ctx.obj["flasher"]
 
     # Parse and validate the firmware image

--- a/universal_silabs_flasher/gbl.py
+++ b/universal_silabs_flasher/gbl.py
@@ -60,11 +60,14 @@ class NabuCasaMetadata:
     fw_type: FirmwareImageType | None
     baudrate: int | None
 
+    original_json: dict[str, typing.Any] = dataclasses.field(repr=False)
+
     def get_public_version(self) -> Version | None:
         return self.ezsp_version or self.ot_rcp_version or self.sdk_version
 
     @classmethod
     def from_json(cls, obj: dict[str, typing.Any]) -> NabuCasaMetadata:
+        original_json = json.loads(json.dumps(obj))
         metadata_version = obj.pop("metadata_version")
 
         if metadata_version > NABUCASA_METADATA_VERSION:
@@ -97,6 +100,7 @@ class NabuCasaMetadata:
             ot_rcp_version=ot_rcp_version,
             fw_type=fw_type,
             baudrate=baudrate,
+            original_json=original_json,
         )
 
 


### PR DESCRIPTION
Useful for extracting information from the firmware files when using the flasher as an entry point:
```console
$ universal-silabs-flasher dump-gbl-metadata --firmware ~/Downloads/NabuCasa_SkyConnect_EZSP_v7.1.3.0_ncp-uart-hw_115200.gbl
2023-04-05 02:59:10 ubuntu universal_silabs_flasher.flash[30238] INFO Extracted GBL metadata: NabuCasaMetadata(metadata_version=1, sdk_version='4.1.3', ezsp_version='7.1.3.0', ot_rcp_version=None, fw_type=<FirmwareImageType.NCP_UART_HW: 'ncp-uart-hw'>, baudrate=None)
{"metadata_version": 1, "sdk_version": "4.1.3", "ezsp_version": "7.1.3.0", "fw_type": "ncp-uart-hw"}
```