### PR TITLE
Add command to probe running firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Options:
 Commands:
   dump-gbl-metadata
   flash
+  probe
   write-ieee
 ```
 

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -218,6 +218,23 @@ async def dump_gbl_metadata(ctx: click.Context, firmware: typing.BinaryIO) -> No
 
     print(json.dumps(metadata_obj))
 
+@main.command()
+@click.pass_context
+@click_coroutine
+async def probe(ctx: click.Context) -> None:
+    flasher = ctx.obj["flasher"]
+
+    try:
+        await flasher.probe_app_type()
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+
+    if flasher.app_type == ApplicationType.EZSP:
+        _LOGGER.info("Dumping EmberZNet Config")
+        try:
+            await flasher.dump_emberznet_config()
+        except RuntimeError as e:
+            raise click.ClickException(str(e)) from e
 
 @main.command()
 @click.pass_context

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -325,6 +325,17 @@ class Flasher:
             if run_firmware:
                 await gecko.run_firmware()
 
+    async def dump_emberznet_config(self) -> None:
+        if self.app_type != ApplicationType.EZSP:
+            raise RuntimeError(f"Device is not running EmberZNet: {self.app_type}")
+
+        async with self._connect_ezsp(self.app_baudrate) as ezsp:
+            for config in ezsp.types.EzspConfigId:
+                v = await ezsp.getConfigurationValue(config)
+                if v[0] == bellows.types.EzspStatus.ERROR_INVALID_ID:
+                    continue
+                print(f"{config.name}={v[1]}")
+
     async def write_emberznet_eui64(self, new_eui64: bellows.types.EUI64) -> bool:
         await self.probe_app_type()
 


### PR DESCRIPTION
As I have a growing pile of adapters with various firmwares installed thought it would be useful adding a command to probe the running firmware without flashing. Fixes #16 

If the adapter is running EZSP use bellows to dump the config as well.