### PR TITLE
Fix to probe metadata baudrate first

### DIFF
--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -307,10 +307,10 @@ async def flash(
         # Probe with the firmware's baudrate first
         if (
             metadata.baudrate is not None
-            and ctx.parent.get_parameter_source(app_type.name)
+            and ctx.parent.get_parameter_source(f"{app_type.value}_baudrate")
             == click.core.ParameterSource.DEFAULT
         ):
-            _LOGGER.debug("Probing with %s baudrate first", app_type)
+            _LOGGER.debug("Probing with %s baudrate first", metadata.baudrate)
             flasher._baudrates[app_type] = put_first(
                 flasher._baudrates[app_type], [metadata.baudrate]
             )


### PR DESCRIPTION
I guess this got broken with the previous baudrate option changes? This correctly matches the relevant app baudrate option.