### PR TITLE
Add a small delay after entering the bootloader with CPC

### DIFF
--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -232,6 +232,9 @@ class CPCProtocol(SerialProtocol):
             command_payload=ResetCommand(status=None),
         )
 
+        # A small delay is necessary when switching baudrates
+        await asyncio.sleep(0.5)
+
     async def get_cpc_version(self) -> Version:
         """Read the secondary CPC version from the device."""
         rsp = await self.send_unnumbered_frame(


### PR DESCRIPTION
Fixes #38.

---

Looks like switching baudrates may be a problem, as I ran into this same issue when implementing the Spinel protocol. I was never able to replicate this on macOS so I think this may be a glitch restricted to the Linux kernel.