### PR TITLE
Compatibility with gpiod 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "zigpy",
     "crc",
     "bellows~=0.37.1",
-    'gpiod>=2.0.2; platform_system=="Linux"',
+    'gpiod==1.5.4; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",
     "typing_extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "zigpy",
     "crc",
     "bellows~=0.37.1",
-    'gpiod; platform_system=="Linux"',
+    'gpiod>=2.0.2; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",
     "typing_extensions",

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -16,10 +16,7 @@ import serial_asyncio
 import zigpy.serial
 
 if typing.TYPE_CHECKING:
-    try:
-        from typing import Self
-    except ImportError:
-        from typing_extensions import Self
+    from typing_extensions import Self
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -257,14 +254,14 @@ class Version:
         prefix_length = min(len(our_comparable), len(their_comparable))
         return our_comparable[:prefix_length] == their_comparable[:prefix_length]
 
-    def __eq__(self, other: Self) -> bool:
-        if not isinstance(other, type(self)):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Version):
             return NotImplemented
 
         return self.components == other.components
 
-    def __lt__(self, other: Self) -> bool:
-        if not isinstance(other, type(self)):
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
             return NotImplemented
 
         our_comparable = self.comparable_components()

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -44,9 +44,12 @@ def _send_gpio_pattern(pin_states: dict[int, list[bool]], toggle_delay: float) -
         # Send all subsequent states
         for i in range(1, num_states):
             time.sleep(toggle_delay)
-
-            for pin, states in pin_states.items():
-                request.set_value(pin, gpiod.line.Value(int(pin_states[pin][i])))
+            request.set_values(
+                {
+                    pin: gpiod.line.Value(int(pin_states[pin][i]))
+                    for pin, states in pin_states.items()
+                }
+            )
 
 
 async def send_gpio_pattern(

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -56,7 +56,7 @@ class Flasher:
         _LOGGER.info("Triggering Yellow bootloader")
 
         await send_gpio_pattern(
-            chip=0,
+            chip="/dev/gpiochip0",
             pin_states={
                 24: [True, False, False, True],
                 25: [True, False, True, True],

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -58,8 +58,8 @@ class Flasher:
         await send_gpio_pattern(
             chip=0,
             pin_states={
-                24: [True, False, False],
-                25: [True, False, True],
+                24: [True, False, False, True],
+                25: [True, False, True, True],
             },
             toggle_delay=0.1,
         )

--- a/universal_silabs_flasher/gpio.py
+++ b/universal_silabs_flasher/gpio.py
@@ -60,12 +60,21 @@ else:
                 for pin, states in pin_states.items()
             },
         ) as request:
-            # Send all subsequent states
-            for i in range(1, num_states):
-                time.sleep(toggle_delay)
-                request.set_values(
+            try:
+                # Send all subsequent states
+                for i in range(1, num_states):
+                    time.sleep(toggle_delay)
+                    request.set_values(
+                        {
+                            pin: gpiod.line.Value(int(pin_states[pin][i]))
+                            for pin, states in pin_states.items()
+                        }
+                    )
+            finally:
+                # Clean up and ensure the GPIO pins are reset to inputs
+                request.reconfigure_lines(
                     {
-                        pin: gpiod.line.Value(int(pin_states[pin][i]))
+                        pin: gpiod.LineSettings(direction=gpiod.line.Direction.INPUT)
                         for pin, states in pin_states.items()
                     }
                 )

--- a/universal_silabs_flasher/gpio.py
+++ b/universal_silabs_flasher/gpio.py
@@ -1,0 +1,81 @@
+import asyncio
+import time
+
+try:
+    import gpiod
+except ImportError:
+    gpiod = None
+
+if gpiod is None:
+    # No gpiod library
+    def _send_gpio_pattern(
+        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
+    ) -> None:
+        raise NotImplementedError()
+
+elif hasattr(gpiod, "line_request"):
+    # gpiod <= 1.5.4
+    def _send_gpio_pattern(
+        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
+    ) -> None:
+        chip = gpiod.chip(0, gpiod.chip.OPEN_BY_NUMBER)
+        lines = {pin: chip.get_line(pin) for pin in pin_states.keys()}
+
+        config = gpiod.line_request()
+        config.consumer = "universal-silabs-flasher"
+        config.request_type = gpiod.line_request.DIRECTION_OUTPUT
+
+        try:
+            # Open the pins and set their initial states
+            for pin, line in lines.items():
+                state = pin_states[pin][0]
+                line.request(config, int(state))
+
+            time.sleep(toggle_delay)
+
+            # Send all subsequent states
+            for i in range(1, len(pin_states[pin])):
+                for pin, line in lines.items():
+                    line.set_value(int(pin_states[pin][i]))
+        finally:
+            # Clean up and ensure the GPIO pins are reset to inputs
+            for line in lines.values():
+                line.set_direction_input()
+
+else:
+    # gpiod >= 2.0.2
+    def _send_gpio_pattern(
+        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
+    ) -> None:
+        # `gpiod` isn't available on Windows
+        num_states = len(next(iter(pin_states.values())))
+
+        with gpiod.request_lines(
+            path=chip,
+            consumer="universal-silabs-flasher",
+            config={
+                # Set initial states
+                pin: gpiod.LineSettings(
+                    direction=gpiod.line.Direction.OUTPUT,
+                    output_value=gpiod.line.Value(states[0]),
+                )
+                for pin, states in pin_states.items()
+            },
+        ) as request:
+            # Send all subsequent states
+            for i in range(1, num_states):
+                time.sleep(toggle_delay)
+                request.set_values(
+                    {
+                        pin: gpiod.line.Value(int(pin_states[pin][i]))
+                        for pin, states in pin_states.items()
+                    }
+                )
+
+
+async def send_gpio_pattern(
+    chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
+) -> None:
+    await asyncio.get_running_loop().run_in_executor(
+        None, _send_gpio_pattern, chip, pin_states, toggle_delay
+    )

--- a/universal_silabs_flasher/gpio.py
+++ b/universal_silabs_flasher/gpio.py
@@ -13,7 +13,7 @@ if gpiod is None:
     ) -> None:
         raise NotImplementedError()
 
-elif hasattr(gpiod, "line_request"):
+elif hasattr(gpiod.chip, "OPEN_BY_PATH"):
     # gpiod <= 1.5.4
     def _send_gpio_pattern(
         chip: str, pin_states: dict[int, list[bool]], toggle_delay: float


### PR DESCRIPTION
Resetting the GPIO pin state after releasing the line is now apparently deprecated, as the new kernel API reverts the pins to an unknown "default" state after the last line request is released.