### PR TITLE
Bootloader reset improvements

### DIFF
--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -21,7 +21,6 @@ class ApplicationType(enum.Enum):
     EZSP = "ezsp"
     SPINEL = "spinel"
 
-
 FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
     FirmwareImageType.NCP_UART_HW: ApplicationType.EZSP,
     FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
@@ -36,3 +35,7 @@ DEFAULT_BAUDRATES = {
     ApplicationType.EZSP: [115200],
     ApplicationType.SPINEL: [460800],
 }
+
+class ResetTarget(enum.Enum):
+    YELLOW = "yellow"
+    SONOFF = "sonoff"

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -40,6 +40,7 @@ DEFAULT_BAUDRATES = {
 
 class ResetTarget(enum.Enum):
     YELLOW = "yellow"
+    IHOST = "ihost"
     SONOFF = "sonoff"
 
 
@@ -49,6 +50,14 @@ GPIO_CONFIGS = {
         "pin_states": {
             24: [True, False, False, True],
             25: [True, False, True, True],
+        },
+        "toggle_delay": 0.1,
+    },
+    ResetTarget.IHOST: {
+        "chip": "/dev/gpiochip1",
+        "pin_states": {
+            27: [True, False, False, True],
+            26: [True, False, True, True],
         },
         "toggle_delay": 0.1,
     },

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -21,6 +21,7 @@ class ApplicationType(enum.Enum):
     EZSP = "ezsp"
     SPINEL = "spinel"
 
+
 FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
     FirmwareImageType.NCP_UART_HW: ApplicationType.EZSP,
     FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
@@ -36,6 +37,19 @@ DEFAULT_BAUDRATES = {
     ApplicationType.SPINEL: [460800],
 }
 
+
 class ResetTarget(enum.Enum):
     YELLOW = "yellow"
     SONOFF = "sonoff"
+
+
+GPIO_CONFIGS = {
+    ResetTarget.YELLOW: {
+        "chip": "/dev/gpiochip0",
+        "pin_states": {
+            24: [True, False, False, True],
+            25: [True, False, True, True],
+        },
+        "toggle_delay": 0.1,
+    },
+}

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -18,7 +18,12 @@ import zigpy.ota.validators
 import zigpy.types
 
 from .common import CommaSeparatedNumbers, patch_pyserial_asyncio, put_first
-from .const import DEFAULT_BAUDRATES, FW_IMAGE_TYPE_TO_APPLICATION_TYPE, ApplicationType, ResetTarget
+from .const import (
+    DEFAULT_BAUDRATES,
+    FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
+    ApplicationType,
+    ResetTarget,
+)
 from .flasher import Flasher
 from .gbl import FirmwareImageType, GBLImage
 from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE, ReceiverCancelled

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -156,6 +156,17 @@ def main(
             " (see `--help`)"
         )
 
+    # To maintain some backwards compatibility, make `--device` required only when we
+    # are actually invoking a command that interacts with a device
+    if ctx.get_parameter_source(
+        "device"
+    ) == click.core.ParameterSource.DEFAULT and ctx.invoked_subcommand not in (
+        dump_gbl_metadata.name
+    ):
+        # Replicate the "Error: Missing option" traceback
+        param = next(p for p in ctx.command.params if p.name == "device")
+        raise click.MissingParameter(ctx=ctx, param=param)
+
     ctx.obj = {
         "verbosity": verbose,
         "flasher": Flasher(
@@ -169,28 +180,6 @@ def main(
             probe_methods=probe_method,
         ),
     }
-    # To maintain some backwards compatibility, make `--device` required only when we
-    # are actually invoking a command that interacts with a device
-    if ctx.get_parameter_source(
-        "device"
-    ) == click.core.ParameterSource.DEFAULT and ctx.invoked_subcommand not in (
-        dump_gbl_metadata.name
-    ):
-        # Replicate the "Error: Missing option" traceback
-        param = next(p for p in ctx.command.params if p.name == "device")
-        raise click.MissingParameter(ctx=ctx, param=param)
-
-    ctx.obj["flasher"] = Flasher(
-        device=device,
-        baudrates={
-            ApplicationType.GECKO_BOOTLOADER: bootloader_baudrate,
-            ApplicationType.CPC: cpc_baudrate,
-            ApplicationType.EZSP: ezsp_baudrate,
-            ApplicationType.SPINEL: spinel_baudrate,
-        },
-        probe_methods=probe_method,
-    )
-
 
 @main.command()
 @click.pass_context

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -143,7 +143,6 @@ class SerialPort(click.ParamType):
     "--bootloader-reset",
     type=click.Choice([t.value for t in ResetTarget]),
 )
-
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -192,6 +191,7 @@ def main(
             bootloader_reset=bootloader_reset,
         ),
     }
+
 
 @main.command()
 @click.pass_context

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -18,7 +18,7 @@ import zigpy.ota.validators
 import zigpy.types
 
 from .common import CommaSeparatedNumbers, patch_pyserial_asyncio, put_first
-from .const import DEFAULT_BAUDRATES, FW_IMAGE_TYPE_TO_APPLICATION_TYPE, ApplicationType
+from .const import DEFAULT_BAUDRATES, FW_IMAGE_TYPE_TO_APPLICATION_TYPE, ApplicationType, ResetTarget
 from .flasher import Flasher
 from .gbl import FirmwareImageType, GBLImage
 from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE, ReceiverCancelled
@@ -134,6 +134,11 @@ class SerialPort(click.ParamType):
     callback=click_enum_validator_factory(ApplicationType),
     show_default=True,
 )
+@click.option(
+    "--bootloader-reset",
+    type=click.Choice([t.value for t in ResetTarget]),
+)
+
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -145,6 +150,7 @@ def main(
     ezsp_baudrate: list[int],
     spinel_baudrate: list[int],
     probe_method: list[ApplicationType],
+    bootloader_reset: str | None,
 ) -> None:
     coloredlogs.install(level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, verbose)])
 
@@ -178,6 +184,7 @@ def main(
                 ApplicationType.SPINEL: spinel_baudrate,
             },
             probe_methods=probe_method,
+            bootloader_reset=bootloader_reset,
         ),
     }
 

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -317,12 +317,20 @@ async def flash(
             flasher._baudrates[app_type] = put_first(
                 flasher._baudrates[app_type], [metadata.baudrate]
             )
+    # Maintain backward compatibility with the deprecated reset flags
+    reset_msg = (
+        "The '%s' flag is deprecated. Use '--bootloader-reset' "
+        "instead, see --help for details."
+    )
+    if yellow_gpio_reset:
+        flasher._reset_target = ResetTarget.YELLOW
+        _LOGGER.info(reset_msg, "--yellow-gpio-reset")
+    elif sonoff_reset:
+        flasher._reset_target = ResetTarget.SONOFF
+        _LOGGER.info(reset_msg, "--sonoff-reset")
 
     try:
-        await flasher.probe_app_type(
-            yellow_gpio_reset=yellow_gpio_reset,
-            sonoff_reset=sonoff_reset,
-        )
+        await flasher.probe_app_type()
     except RuntimeError as e:
         raise click.ClickException(str(e)) from e
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -158,12 +158,14 @@ class Flasher:
 
         bootloader_probe = None
 
-        # Only run firmware from the bootloader if we have other probe methods
+        # Only run firmware from the bootloader if we have bootloader reset and
+        # other probe methods
         only_probe_bootloader = types == [ApplicationType.GECKO_BOOTLOADER]
+        run_firmware = self._reset_target and not only_probe_bootloader
         probe_funcs = {
             ApplicationType.GECKO_BOOTLOADER: (
                 lambda baudrate: self.probe_gecko_bootloader(
-                    run_firmware=(not only_probe_bootloader), baudrate=baudrate
+                    run_firmware=run_firmware, baudrate=baudrate
                 )
             ),
             ApplicationType.CPC: self.probe_cpc,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -11,7 +11,7 @@ import bellows.ezsp
 import bellows.types
 
 from .common import PROBE_TIMEOUT, SerialProtocol, Version, connect_protocol
-from .const import DEFAULT_BAUDRATES, ApplicationType
+from .const import DEFAULT_BAUDRATES, ApplicationType, ResetTarget
 from .cpc import CPCProtocol
 from .emberznet import connect_ezsp
 from .gbl import GBLImage
@@ -42,6 +42,7 @@ class Flasher:
             ApplicationType.SPINEL,
         ),
         device: str,
+        bootloader_reset: str,
     ):
         self._baudrates = baudrates
         self._probe_methods = probe_methods
@@ -51,6 +52,10 @@ class Flasher:
         self.app_version: Version | None = None
         self.app_baudrate: int | None = None
         self.bootloader_baudrate: int | None = None
+
+        self._reset_target: ResetTarget | None = (
+            ResetTarget(bootloader_reset) if bootloader_reset else None
+        )
 
     async def enter_yellow_bootloader(self):
         _LOGGER.info("Triggering Yellow bootloader")


### PR DESCRIPTION
I have two more devices to add support for bootloader reset. The first is the Sonoff iHost included in this series, second will be a forthcoming device from Smlight.

The current bootloader reset implementation doesnt really scale cleanly for adding more devices, so I have split it out into a new `--bootloader-reset` option. I made it a global option so it can be shared with both `probe` and `flash` commands. Kept compatibility with the previous individual device flags, in case there is any usage from scripts currently.