### PR TITLE
Disconnect stream writer without closing the transport

### DIFF
--- a/universal_silabs_flasher/xmodemcrc.py
+++ b/universal_silabs_flasher/xmodemcrc.py
@@ -153,7 +153,7 @@ async def send_xmodem128_crc(
         _WRITER_GRAVEYARD = [
             w
             for w in _WRITER_GRAVEYARD
-            if w.transport is None or w.transport.is_closing()
+            if w.transport is not None and not w.transport.is_closing()
         ]
 
         # Reset the old protocol

--- a/universal_silabs_flasher/xmodemcrc.py
+++ b/universal_silabs_flasher/xmodemcrc.py
@@ -149,6 +149,16 @@ async def send_xmodem128_crc(
         # XXX: Make sure the writer doesn't close our transport when garbage collected
         _WRITER_GRAVEYARD.append(writer)
 
+        stale_entries = [
+            index
+            for index, writer in enumerate(_WRITER_GRAVEYARD)
+            if writer.transport.is_closing()
+        ]
+
+        for index in stale_entries[::-1]:
+            _LOGGER.debug("Removing stale writer %s", _WRITER_GRAVEYARD[index])
+            del _WRITER_GRAVEYARD[index]
+
         # Reset the old protocol
         transport.set_protocol(old_protocol)
 


### PR DESCRIPTION
Fixes #57.

CPython changed the functionality of `StreamWriter.__del__` to automatically close the underlying transport when the writer object is deleted: https://github.com/python/cpython/issues/109321.

This behavior silently closed the serial port upon completion of the XMODEM transfer on newer CPython patch releases, something that did not happen earlier. I only caught it by swapping in https://github.com/puddly/serialpy with debug logging.

The alternative to this PR (that does not rely on private attribute access) is to keep all `StreamWriter` objects around in a global graveyard list after use.