### PR TITLE
Fix init error in sl-web-tools

### DIFF
--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -50,7 +50,7 @@ class Flasher:
             ApplicationType.SPINEL,
         ),
         device: str,
-        bootloader_reset: str,
+        bootloader_reset: str | None = None,
     ):
         self._baudrates = baudrates
         self._probe_methods = probe_methods


### PR DESCRIPTION
This is tripping up sl-web-tools (with 0.0.16 release), and I suppose may also impact zha:
```
pyodide.asm.js:9  Uncaught (in promise) PythonError: Traceback (most recent call last):
  File "<exec>", line 5, in create_flasher
TypeError: Flasher.__init__() missing 1 required keyword-only argument: 'bootloader_reset'

    at new_error (pyodide.asm.js:9:12519)
    at pyodide.asm.wasm:0x158827
    at pyodide.asm.wasm:0x15892c
    at Module._pythonexc2js (pyodide.asm.js:9:640895)
    at Module.callPyObjectKwargs (pyodide.asm.js:9:81856)
    at Proxy.callKwargs (pyodide.asm.js:9:97507)
    at HTMLElement.onPyodideLoaded (flashing-dialog-9eb83a56.js:281:1232)
    at HTMLElement.selectSerialPort (flashing-dialog-9eb83a56.js:281:507)
```