### PR TITLE
Read CPC firmware secondary version

### DIFF
--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -31,6 +31,7 @@ def test_firmware_gbl_valid_with_metadata():
         metadata_version=1,
         sdk_version=Version("4.1.3"),
         ezsp_version=None,
+        cpc_version=None,
         fw_type=firmware.FirmwareImageType.RCP_UART_802154,
         ot_rcp_version=None,
         baudrate=None,

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -246,6 +246,7 @@ class Version:
         # 7.2.2.0 build 190
         # 4.2.2
         # SL-OPENTHREAD/2.2.2.0_GitHub-91fa1f455
+        # 4.4.0-2546d625-dirty-676fdb09
         for component in self._SEPARATORS_REGEX.split(version):
             if component.isdigit():
                 self.components.append(

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -14,6 +14,12 @@ class FirmwareImageType(enum.Enum):
     # OpenThread RCP
     OT_RCP = "ot-rcp"
 
+    # Z-Wave
+    Z_WAVE = "z-wave"
+
+    # Gecko Bootloader
+    GECKO_BOOTLOADER = "gecko-bootloader"
+
 
 class ApplicationType(enum.Enum):
     GECKO_BOOTLOADER = "bootloader"
@@ -27,6 +33,7 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
     FirmwareImageType.RCP_UART_802154: ApplicationType.CPC,
     FirmwareImageType.ZIGBEE_NCP_RCP_UART_802154: ApplicationType.CPC,
     FirmwareImageType.OT_RCP: ApplicationType.SPINEL,
+    FirmwareImageType.GECKO_BOOTLOADER: ApplicationType.GECKO_BOOTLOADER,
 }
 
 

--- a/universal_silabs_flasher/firmware.py
+++ b/universal_silabs_flasher/firmware.py
@@ -69,6 +69,7 @@ class NabuCasaMetadata:
     sdk_version: Version | None
     ezsp_version: Version | None
     ot_rcp_version: Version | None
+    cpc_version: Version | None
 
     fw_type: FirmwareImageType | None
     baudrate: int | None
@@ -76,7 +77,12 @@ class NabuCasaMetadata:
     original_json: dict[str, typing.Any] = dataclasses.field(repr=False)
 
     def get_public_version(self) -> Version | None:
-        return self.ezsp_version or self.ot_rcp_version or self.sdk_version
+        return (
+            self.cpc_version
+            or self.ezsp_version
+            or self.ot_rcp_version
+            or self.sdk_version
+        )
 
     @classmethod
     def from_json(cls, obj: dict[str, typing.Any]) -> NabuCasaMetadata:
@@ -98,6 +104,9 @@ class NabuCasaMetadata:
         if ot_rcp_version := obj.pop("ot_rcp_version", None):
             ot_rcp_version = Version(ot_rcp_version)
 
+        if cpc_version := obj.pop("cpc_version", None):
+            cpc_version = Version(cpc_version)
+
         if fw_type := obj.pop("fw_type", None):
             fw_type = FirmwareImageType(fw_type)
 
@@ -111,6 +120,7 @@ class NabuCasaMetadata:
             sdk_version=sdk_version,
             ezsp_version=ezsp_version,
             ot_rcp_version=ot_rcp_version,
+            cpc_version=cpc_version,
             fw_type=fw_type,
             baudrate=baudrate,
             original_json=original_json,

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -382,17 +382,17 @@ async def flash(
                     flasher.app_baudrate,
                     metadata.baudrate,
                 )
-            elif app_version.compatible_with(fw_version):
-                _LOGGER.info(
-                    "Firmware version %s is flashed, not re-installing", app_version
-                )
-                return
-            elif ensure_exact_version and not app_version.compatible_with(fw_version):
+            elif ensure_exact_version and app_version != fw_version:
                 _LOGGER.info(
                     "Firmware version %s does not match expected version %s",
                     fw_version,
                     app_version,
                 )
+            elif app_version.compatible_with(fw_version):
+                _LOGGER.info(
+                    "Firmware version %s is flashed, not re-installing", app_version
+                )
+                return
             elif not allow_downgrades and app_version > fw_version:
                 _LOGGER.info(
                     "Firmware version %s does not upgrade current version %s",


### PR DESCRIPTION
New CPC firmwares will set the secondary version, allowing us to detect the exact version (specified at build time).

I've also fixed `--ensure-exact-version` to make sure `4.4.0-2546d625-dirty-676fdb09` and `4.4.0` are seen as different versions.