### PR TITLE
Add bootloader reset for SMLIGHT SLZB-07

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Options:
   --ezsp-baudrate NUMBERS        [default: 115200]
   --spinel-baudrate NUMBERS      [default: 460800]
   --probe-method TEXT            [default: bootloader, cpc, ezsp, spinel]
-  --bootloader-reset [yellow|ihost|sonoff]
+  --bootloader-reset [yellow|ihost|slzb07|sonoff]
   --help                         Show this message and exit.
 
 Commands:

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -48,6 +48,7 @@ DEFAULT_BAUDRATES = {
 class ResetTarget(enum.Enum):
     YELLOW = "yellow"
     IHOST = "ihost"
+    SLZB07 = "slzb07"
     SONOFF = "sonoff"
 
 
@@ -65,6 +66,14 @@ GPIO_CONFIGS = {
         "pin_states": {
             27: [True, False, False, True],
             26: [True, False, True, True],
+        },
+        "toggle_delay": 0.1,
+    },
+    ResetTarget.SLZB07: {
+        "chip_name": "cp210x",
+        "pin_states": {
+            5: [True, False, False, True],
+            4: [True, False, True, True],
         },
         "toggle_delay": 0.1,
     },

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -70,6 +70,10 @@ class Flasher:
         if target in GPIO_CONFIGS.keys():
             config = GPIO_CONFIGS[target]
             if "chip" not in config.keys():
+                _LOGGER.warning(
+                    f"When using {target.value} bootloader reset "
+                    + "ensure no other CP2102 USB serial devices are connected."
+                )
                 config["chip"] = await find_gpiochip_by_label(config["chip_name"])
             await send_gpio_pattern(
                 config["chip"], config["pin_states"], config["toggle_delay"]

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -22,7 +22,7 @@ from .cpc import CPCProtocol
 from .emberznet import connect_ezsp
 from .firmware import FirmwareImage
 from .gecko_bootloader import GeckoBootloaderProtocol, NoFirmwareError
-from .gpio import send_gpio_pattern
+from .gpio import find_gpiochip_by_label, send_gpio_pattern
 from .spinel import SpinelProtocol
 from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE
 
@@ -69,6 +69,8 @@ class Flasher:
         _LOGGER.info(f"Triggering {target.value} bootloader")
         if target in GPIO_CONFIGS.keys():
             config = GPIO_CONFIGS[target]
+            if "chip" not in config.keys():
+                config["chip"] = await find_gpiochip_by_label(config["chip_name"])
             await send_gpio_pattern(
                 config["chip"], config["pin_states"], config["toggle_delay"]
             )


### PR DESCRIPTION
New hardware revision of SMLIGHT SLZB-07 dongle will have bootloader reset hooked up to the GPIO on the CP2102N chip. GPIO drivers for this have been included in mainline Linux since long ago and it works fine with gpiod.

As this is a USB chip the actual chip number for the `/dev/gpiochip` device will depend on what other system gpio devices might already exist on the system. So have added support to search by chip label to find the chip number, which will return the path of first found CP210X USB chip. Both gpiod API's are covered and have been tested.

slzb-07 is added with the `chip_name` key to activate above search.

Patches by @darkxst on behalf of @smlight-dev.

