### PR TITLE
Bump minimum bellows version to 0.38.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "zigpy",
     "crc",
-    "bellows~=0.37.1",
+    "bellows~=0.38.0",
     'gpiod==1.5.4; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",


### PR DESCRIPTION
Without this change, the flasher cannot be updated in Home Assistant.