### PR TITLE
Bump bellows to 0.39.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
       PYTHON_VERSION_DEFAULT: 3.8.14
       PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 40
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "zigpy",
     "crc",
-    "bellows~=0.38.0",
+    "bellows~=0.39.0",
     'gpiod==1.5.4; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",


### PR DESCRIPTION
Unblocks https://github.com/home-assistant/core/pull/118658.