### PR TITLE
Drop hard dependency on `gpiod==1.5.4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "zigpy",
     "crc",
     "bellows~=0.39.0",
-    'gpiod==1.5.4; platform_system=="Linux"',
+    'gpiod; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",
     "typing_extensions",


### PR DESCRIPTION
`gpiod` started publishing installable wheels as of version 2.2.0.