### PR TITLE
Bump bellows to 0.41.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click>=8.0.0",
     "zigpy",
     "crc",
-    "bellows~=0.40.0",
+    "bellows~=0.41.0",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",


### PR DESCRIPTION
Needed to unblock the dependency bump in Core.