### PR TITLE
Wait for serial port close when disconnecting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click>=8.0.0",
     "zigpy",
     "crc",
-    "bellows~=0.41.0",
+    "bellows",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "coloredlogs",
     "async_timeout",
     "typing_extensions",
+    "pyserial-asyncio-fast",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click>=8.0.0",
     "zigpy>=0.70.0",
     "crc",
-    "bellows",
+    "bellows>=0.42.0",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
     "async_timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
     "click>=8.0.0",
-    "zigpy",
+    "zigpy>=0.70.0",
     "crc",
     "bellows",
     'gpiod; platform_system=="Linux"',

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -125,16 +125,27 @@ class SerialProtocol(asyncio.Protocol):
         self._buffer = bytearray()
         self._transport: serial_asyncio.SerialTransport | None = None
         self._connected_event = asyncio.Event()
+        self._disconnected_event = asyncio.Event()
 
     async def wait_until_connected(self) -> None:
         """Wait for the protocol's transport to be connected."""
         await self._connected_event.wait()
+
+    async def wait_closed(self) -> None:
+        await self._disconnected_event.wait()
 
     def connection_made(self, transport: serial_asyncio.SerialTransport) -> None:
         _LOGGER.debug("Connection made: %s", transport)
 
         self._transport = transport
         self._connected_event.set()
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        _LOGGER.debug("Connection lost: %s", exc)
+
+        self._transport = None
+        self._connected_event.clear()
+        self._disconnected_event.set()
 
     def send_data(self, data: bytes) -> None:
         """Sends data over the connected transport."""
@@ -147,7 +158,7 @@ class SerialProtocol(asyncio.Protocol):
         _LOGGER.debug("Received data %s", data)
         self._buffer += data
 
-    def disconnect(self) -> None:
+    def close(self) -> None:
         if self._transport is not None:
             self._transport.close()
             self._buffer.clear()
@@ -189,10 +200,8 @@ async def connect_protocol(port, baudrate, factory):
     try:
         yield protocol
     finally:
-        protocol.disconnect()
-
-        # Required for Windows to be able to re-connect to the same serial port
-        await asyncio.sleep(0)
+        protocol.close()
+        await protocol.wait_closed()
 
 
 class CommaSeparatedNumbers(click.ParamType):

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -12,7 +12,6 @@ import typing
 import async_timeout
 import click
 import crc
-import serial_asyncio
 import zigpy.serial
 
 if typing.TYPE_CHECKING:
@@ -116,53 +115,6 @@ class StateMachine:
         finally:
             # Always clean up the future
             self._futures_for_state[state].remove(future)
-
-
-class SerialProtocol(asyncio.Protocol):
-    """Base class for packet-parsing serial protocol implementations."""
-
-    def __init__(self) -> None:
-        self._buffer = bytearray()
-        self._transport: serial_asyncio.SerialTransport | None = None
-        self._connected_event = asyncio.Event()
-        self._disconnected_event = asyncio.Event()
-
-    async def wait_until_connected(self) -> None:
-        """Wait for the protocol's transport to be connected."""
-        await self._connected_event.wait()
-
-    async def wait_closed(self) -> None:
-        await self._disconnected_event.wait()
-
-    def connection_made(self, transport: serial_asyncio.SerialTransport) -> None:
-        _LOGGER.debug("Connection made: %s", transport)
-
-        self._transport = transport
-        self._connected_event.set()
-
-    def connection_lost(self, exc: Exception | None) -> None:
-        _LOGGER.debug("Connection lost: %s", exc)
-
-        self._transport = None
-        self._connected_event.clear()
-        self._disconnected_event.set()
-
-    def send_data(self, data: bytes) -> None:
-        """Sends data over the connected transport."""
-        assert self._transport is not None
-        data = bytes(data)
-        _LOGGER.debug("Sending data %s", data)
-        self._transport.write(data)
-
-    def data_received(self, data: bytes) -> None:
-        _LOGGER.debug("Received data %s", data)
-        self._buffer += data
-
-    def close(self) -> None:
-        if self._transport is not None:
-            self._transport.close()
-            self._buffer.clear()
-            self._connected_event.clear()
 
 
 @contextlib.asynccontextmanager

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -165,25 +165,6 @@ class SerialProtocol(asyncio.Protocol):
             self._connected_event.clear()
 
 
-def patch_pyserial_asyncio() -> None:
-    """Patches pyserial-asyncio's `SerialTransport` to support swapping protocols."""
-
-    if (
-        serial_asyncio.SerialTransport.get_protocol
-        is not asyncio.BaseTransport.get_protocol
-    ):
-        return
-
-    def get_protocol(self) -> asyncio.Protocol:
-        return self._protocol
-
-    def set_protocol(self, protocol: asyncio.Protocol) -> None:
-        self._protocol = protocol
-
-    serial_asyncio.SerialTransport.get_protocol = get_protocol
-    serial_asyncio.SerialTransport.set_protocol = set_protocol
-
-
 @contextlib.asynccontextmanager
 async def connect_protocol(port, baudrate, factory):
     loop = asyncio.get_running_loop()

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -133,8 +133,7 @@ async def connect_protocol(port, baudrate, factory):
     try:
         yield protocol
     finally:
-        protocol.close()
-        await protocol.wait_closed()
+        await protocol.disconnect()
 
 
 class CommaSeparatedNumbers(click.ParamType):

--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -282,6 +282,11 @@ class CPCProtocol(SerialProtocol):
 
         return Version(version_bytes.split(b"\x00", 1)[0].decode("ascii"))
 
+    def send_data(self, data: bytes) -> None:
+        assert self._transport is not None
+        _LOGGER.debug("Sending data %s", data)
+        self._transport.write(data)
+
     def data_received(self, data: bytes) -> None:
         super().data_received(data)
 

--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -6,10 +6,11 @@ import logging
 import typing
 
 import async_timeout
+from zigpy.serial import SerialProtocol
 import zigpy.types
 
 from . import cpc_types
-from .common import BufferTooShort, SerialProtocol, Version, crc16_ccitt
+from .common import BufferTooShort, Version, crc16_ccitt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -208,6 +209,8 @@ class CPCTransportFrame:
 
 class CPCProtocol(SerialProtocol):
     """Partial implementation of the CPC protocol."""
+
+    _buffer: bytearray
 
     def __init__(self) -> None:
         super().__init__()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -17,7 +17,7 @@ import coloredlogs
 import zigpy.ota.validators
 import zigpy.types
 
-from .common import CommaSeparatedNumbers, patch_pyserial_asyncio, put_first
+from .common import CommaSeparatedNumbers, put_first
 from .const import (
     DEFAULT_BAUDRATES,
     FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
@@ -27,8 +27,6 @@ from .const import (
 from .firmware import FirmwareImageType, parse_firmware_image
 from .flasher import Flasher
 from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE, ReceiverCancelled
-
-patch_pyserial_asyncio()
 
 _LOGGER = logging.getLogger(__name__)
 LOG_LEVELS = ["INFO", "DEBUG"]

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -9,14 +9,9 @@ import async_timeout
 import bellows.config
 import bellows.ezsp
 import bellows.types
+from zigpy.serial import SerialProtocol
 
-from .common import (
-    PROBE_TIMEOUT,
-    SerialProtocol,
-    Version,
-    connect_protocol,
-    pad_to_multiple,
-)
+from .common import PROBE_TIMEOUT, Version, connect_protocol, pad_to_multiple
 from .const import DEFAULT_BAUDRATES, GPIO_CONFIGS, ApplicationType, ResetTarget
 from .cpc import CPCProtocol
 from .emberznet import connect_ezsp

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -115,8 +115,6 @@ class Flasher:
                 if run_firmware:
                     await gecko.run_firmware()
                     _LOGGER.info("Launched application from bootloader")
-
-            await asyncio.sleep(1)
         except NoFirmwareError:
             _LOGGER.warning("No application can be launched")
             return ProbeResult(

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -7,8 +7,9 @@ import re
 import typing
 
 import async_timeout
+from zigpy.serial import SerialProtocol
 
-from .common import PROBE_TIMEOUT, SerialProtocol, StateMachine, Version
+from .common import PROBE_TIMEOUT, StateMachine, Version
 from .xmodemcrc import send_xmodem128_crc
 
 _LOGGER = logging.getLogger(__name__)

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -143,6 +143,11 @@ class GeckoBootloaderProtocol(SerialProtocol):
         if self._upload_status != "complete":
             raise UploadError(self._upload_status)
 
+    def send_data(self, data: bytes) -> None:
+        assert self._transport is not None
+        _LOGGER.debug("Sending data %s", data)
+        self._transport.write(data)
+
     def data_received(self, data: bytes) -> None:
         super().data_received(data)
 

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -260,6 +260,3 @@ class SpinelProtocol(SerialProtocol):
             ResetReason.BOOTLOADER.serialize(),
             wait_response=False,
         )
-
-        # A small delay is necessary when switching baudrates
-        await asyncio.sleep(0.5)

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -6,9 +6,10 @@ import logging
 import typing
 
 import async_timeout
+from zigpy.serial import SerialProtocol
 import zigpy.types
 
-from .common import SerialProtocol, Version, crc16_kermit
+from .common import Version, crc16_kermit
 from .spinel_types import CommandID, HDLCSpecial, PropertyID, ResetReason
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,6 +105,8 @@ class SpinelFrame:
 
 
 class SpinelProtocol(SerialProtocol):
+    _buffer: bytearray
+
     def __init__(self) -> None:
         super().__init__()
         self._transaction_id: int = 1

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -112,6 +112,11 @@ class SpinelProtocol(SerialProtocol):
         self._transaction_id: int = 1
         self._pending_frames: dict[int, asyncio.Future] = {}
 
+    def send_data(self, data: bytes) -> None:
+        assert self._transport is not None
+        _LOGGER.debug("Sending data %s", data)
+        self._transport.write(data)
+
     def data_received(self, data: bytes) -> None:
         super().data_received(data)
 


### PR DESCRIPTION
This is basically an implementation of https://github.com/zigpy/zigpy/pull/1425.

We currently have a sort of race condition where consecutive opening and closings of the serial port hide the fact that we don't actually wait for the file to completely close, instead sidestepping the issue (usually) with a small delay. This PR should properly fix the problem.