### PR TITLE
Fix CI dependency issue with aiohttp and async-timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,16 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "GPL-3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
+    "aiohttp",  # Explicit dependency until compatibility with async-timeout is resolved
     "click>=8.0.0",
     "zigpy>=0.70.0",
     "crc",
     "bellows>=0.42.0",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
-    "async_timeout",
+    'async-timeout; python_version<"3.11"',
     "typing_extensions",
     "pyserial-asyncio-fast",
 ]

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -7,12 +7,17 @@ import dataclasses
 import functools
 import logging
 import re
+import sys
 import typing
 
-import async_timeout
 import click
 import crc
 import zigpy.serial
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
+else:
+    from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Self
@@ -121,7 +126,7 @@ class StateMachine:
 async def connect_protocol(port, baudrate, factory):
     loop = asyncio.get_running_loop()
 
-    async with async_timeout.timeout(CONNECT_TIMEOUT):
+    async with asyncio_timeout(CONNECT_TIMEOUT):
         _, protocol = await zigpy.serial.create_serial_connection(
             loop=loop,
             protocol_factory=factory,

--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -5,12 +5,11 @@ import dataclasses
 import logging
 import typing
 
-import async_timeout
 from zigpy.serial import SerialProtocol
 import zigpy.types
 
 from . import cpc_types
-from .common import BufferTooShort, Version, crc16_ccitt
+from .common import BufferTooShort, Version, asyncio_timeout, crc16_ccitt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -354,7 +353,7 @@ class CPCProtocol(SerialProtocol):
                 self.send_data(frame.serialize())
 
                 try:
-                    async with async_timeout.timeout(timeout):
+                    async with asyncio_timeout(timeout):
                         return await asyncio.shield(future)
                 except asyncio.TimeoutError:
                     _LOGGER.debug(

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -5,13 +5,18 @@ import dataclasses
 import logging
 import typing
 
-import async_timeout
 import bellows.config
 import bellows.ezsp
 import bellows.types
 from zigpy.serial import SerialProtocol
 
-from .common import PROBE_TIMEOUT, Version, connect_protocol, pad_to_multiple
+from .common import (
+    PROBE_TIMEOUT,
+    Version,
+    asyncio_timeout,
+    connect_protocol,
+    pad_to_multiple,
+)
 from .const import DEFAULT_BAUDRATES, GPIO_CONFIGS, ApplicationType, ResetTarget
 from .cpc import CPCProtocol
 from .emberznet import connect_ezsp
@@ -244,11 +249,11 @@ class Flasher:
             pass
         elif self.app_type is ApplicationType.CPC:
             async with self._connect_cpc(self.app_baudrate) as cpc:
-                async with async_timeout.timeout(PROBE_TIMEOUT):
+                async with asyncio_timeout(PROBE_TIMEOUT):
                     await cpc.enter_bootloader()
         elif self.app_type is ApplicationType.SPINEL:
             async with self._connect_spinel(self.app_baudrate) as spinel:
-                async with async_timeout.timeout(PROBE_TIMEOUT):
+                async with asyncio_timeout(PROBE_TIMEOUT):
                     await spinel.enter_bootloader()
         elif self.app_type is ApplicationType.EZSP:
             async with self._connect_ezsp(self.app_baudrate) as ezsp:

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -5,11 +5,10 @@ import dataclasses
 import logging
 import typing
 
-import async_timeout
 from zigpy.serial import SerialProtocol
 import zigpy.types
 
-from .common import Version, crc16_kermit
+from .common import Version, asyncio_timeout, crc16_kermit
 from .spinel_types import CommandID, HDLCSpecial, PropertyID, ResetReason
 
 _LOGGER = logging.getLogger(__name__)
@@ -210,7 +209,7 @@ class SpinelProtocol(SerialProtocol):
                 self.send_data(HDLCLiteFrame(data=new_frame.serialize()).serialize())
 
                 try:
-                    async with async_timeout.timeout(timeout):
+                    async with asyncio_timeout(timeout):
                         return await asyncio.shield(future)
                 except asyncio.TimeoutError:
                     _LOGGER.debug(

--- a/universal_silabs_flasher/xmodemcrc.py
+++ b/universal_silabs_flasher/xmodemcrc.py
@@ -5,10 +5,9 @@ import dataclasses
 import logging
 import typing
 
-import async_timeout
 import zigpy.types
 
-from .common import crc16_ccitt
+from .common import asyncio_timeout, crc16_ccitt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +65,7 @@ async def send_xmodem128_crc_data(
         await writer.drain()
 
         # And wait for a response
-        async with async_timeout.timeout(RECEIVE_TIMEOUT):
+        async with asyncio_timeout(RECEIVE_TIMEOUT):
             rsp_byte = await reader.readexactly(1)
 
         _LOGGER.debug("Got response: %r", rsp_byte)


### PR DESCRIPTION
It seems like uv is preferring our explicit dependency on `async-timeout` being the highest version to picking one compatible with `aiohttp`. This results in an ancient version of the latter package being installed.