### PR TITLE
Bump setuptools-git-versioning 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2"]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning>=2.0,<3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Bump to latest stable version

----
### Chaneglog
[v2.0.0](https://github.com/dolfinus/setuptools-git-versioning/releases/tag/v2.0.0) [Latest](https://github.com/dolfinus/setuptools-git-versioning/releases/latest)
core
[breaking] Drop get_branch_tags function which was deprecated since 1.8.0.

[breaking] version_file option now have precedence over any tags in the current branch.

References: https://github.com/dolfinus/setuptools-git-versioning/issues/94, https://github.com/dolfinus/setuptools-git-versioning/issues/97

config
[breaking] Drop version_config keyword from setup.py, which was deprecated since 1.8.0.

[breaking] Does not allow passing setuptools_git_versioning=False and setuptools_git_versioning=True to config.
Always use setuptools_git_versioning={"enabled": True}.