### PR TITLE
Fix issue detecting router prompt

### DIFF
--- a/universal_silabs_flasher/router.py
+++ b/universal_silabs_flasher/router.py
@@ -69,7 +69,7 @@ class RouterProtocol(SerialProtocol):
         while self._buffer:
             _LOGGER.debug("Parsing %s: %r", self._state_machine.state, self._buffer)
             if self._state_machine.state == State.STARTUP:
-                if b"\n>" not in self._buffer:
+                if b">" not in self._buffer:
                     return
 
                 self._buffer.clear()


### PR DESCRIPTION
To go along with sl-web-tools update.

The buffer string containing the router prompt ('>') doesn't consistently contain newline character. Occasionally its missing and flashing will fail. So remove newline char from the string matching the prompt.