### PR TITLE
Add 921600 cpc baudrate.

### DIFF
--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -41,7 +41,7 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
 
 DEFAULT_BAUDRATES = {
     ApplicationType.GECKO_BOOTLOADER: [115200],
-    ApplicationType.CPC: [460800, 115200, 230400],
+    ApplicationType.CPC: [460800, 115200, 230400, 921600],
     ApplicationType.EZSP: [115200],
     ApplicationType.SPINEL: [460800],
     ApplicationType.ROUTER: [115200],


### PR DESCRIPTION
Adds an option to set CPC baudrate to 921600. I haven't had an opportunity to test this on hardware (I don't want to develop on the zigbee stick that's running my house), but no reason it shouldn't work.

Follow up on https://github.com/Nerivec/ember-zli/pull/12 .