### PR TITLE
Merge GPIO and flow control bootloader reset

### DIFF
--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -236,3 +236,33 @@ class Version:
             return f"{concatenated!r}"
 
         return f"{concatenated!r} ({comparable})"
+
+
+class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
+    def _set_flow_control(
+        self,
+        *,
+        rts: bool | None = None,
+        cts: bool | None = None,
+        dtr: bool | None = None,
+    ) -> None:
+        if rts is not None:
+            self.transport.serial.rts = rts
+
+        if cts is not None:
+            self.transport.serial.cts = cts
+
+        if dtr is not None:
+            self.transport.serial.dtr = dtr
+
+    async def set_flow_control(
+        self,
+        *,
+        rts: bool | None = None,
+        cts: bool | None = None,
+        dtr: bool | None = None,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, lambda: self._set_flow_control(rts=rts, cts=cts, dtr=dtr)
+        )

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -239,7 +239,7 @@ class Version:
 
 
 class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
-    def _set_flow_control(
+    def _set_signals(
         self,
         *,
         rts: bool | None = None,
@@ -255,18 +255,18 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         if dtr is not None:
             self.transport.serial.dtr = dtr
 
-    async def set_flow_control(
+    async def set_signals(
         self,
         *,
         rts: bool | None = None,
         cts: bool | None = None,
         dtr: bool | None = None,
     ) -> None:
-        if hasattr(self.transport, "set_flow_control"):
-            await self.transport.set_flow_control(rts=rts, cts=cts, dtr=dtr)
+        if hasattr(self.transport, "set_signals"):
+            await self.transport.set_signals(rts=rts, cts=cts, dtr=dtr)
             return
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
-            None, lambda: self._set_flow_control(rts=rts, cts=cts, dtr=dtr)
+            None, lambda: self._set_signals(rts=rts, cts=cts, dtr=dtr)
         )

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -262,6 +262,10 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         cts: bool | None = None,
         dtr: bool | None = None,
     ) -> None:
+        if hasattr(self.transport, "set_flow_control"):
+            await self.transport.set_flow_control(rts=rts, cts=cts, dtr=dtr)
+            return
+
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None, lambda: self._set_flow_control(rts=rts, cts=cts, dtr=dtr)

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -247,13 +247,13 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         dtr: bool | None = None,
     ) -> None:
         if rts is not None:
-            self.transport.serial.rts = rts
+            self._transport.serial.rts = rts
 
         if cts is not None:
-            self.transport.serial.cts = cts
+            self._transport.serial.cts = cts
 
         if dtr is not None:
-            self.transport.serial.dtr = dtr
+            self._transport.serial.dtr = dtr
 
     async def set_signals(
         self,
@@ -262,8 +262,15 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         cts: bool | None = None,
         dtr: bool | None = None,
     ) -> None:
-        if hasattr(self.transport, "set_signals"):
-            await self.transport.set_signals(rts=rts, cts=cts, dtr=dtr)
+        _LOGGER.debug(
+            "Setting UART signals: rts=%s, cts=%s, dtr=%s",
+            int(rts) if rts is not None else "-",
+            int(cts) if cts is not None else "-",
+            int(dtr) if dtr is not None else "-",
+        )
+
+        if hasattr(self._transport, "set_signals"):
+            await self._transport.set_signals(rts=rts, cts=cts, dtr=dtr)
             return
 
         loop = asyncio.get_running_loop()

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import enum
 

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -1,3 +1,4 @@
+import dataclasses
 import enum
 
 
@@ -52,32 +53,67 @@ class ResetTarget(enum.Enum):
     YELLOW = "yellow"
     IHOST = "ihost"
     SLZB07 = "slzb07"
+    RTS_DTR = "rts_dtr"
+
+    # Deprecated alias for `RTS_DTR`
     SONOFF = "sonoff"
 
 
+@dataclasses.dataclass
+class GpioPattern:
+    pins: dict[str | int, bool]
+    delay_after: float
+
+
+@dataclasses.dataclass
+class GpioResetConfig:
+    chip: str | None
+    chip_type: str | None
+    pattern: list[GpioPattern]
+
+
+# fmt: off
 GPIO_CONFIGS = {
-    ResetTarget.YELLOW: {
-        "chip": "/dev/gpiochip0",
-        "pin_states": {
-            24: [True, False, False, True],
-            25: [True, False, True, True],
-        },
-        "toggle_delay": 0.1,
-    },
-    ResetTarget.IHOST: {
-        "chip": "/dev/gpiochip1",
-        "pin_states": {
-            27: [True, False, False, True],
-            26: [True, False, True, True],
-        },
-        "toggle_delay": 0.1,
-    },
-    ResetTarget.SLZB07: {
-        "chip_name": "cp210x",
-        "pin_states": {
-            5: [True, False, False, True],
-            4: [True, False, True, True],
-        },
-        "toggle_delay": 0.1,
-    },
+    ResetTarget.YELLOW: GpioResetConfig(
+        chip="/dev/gpiochip0",
+        chip_type=None,
+        pattern=[
+            GpioPattern(pins={24: True,  25: True},  delay_after=0.1),
+            GpioPattern(pins={24: False, 25: False}, delay_after=0.1),
+            GpioPattern(pins={24: False, 25: True},  delay_after=0.1),
+            GpioPattern(pins={24: True,  25: True},  delay_after=0.0),
+        ],
+    ),
+    ResetTarget.IHOST: GpioResetConfig(
+        chip="/dev/gpiochip1",
+        chip_type=None,
+        pattern=[
+            GpioPattern(pins={26: True,  27: True},  delay_after=0.1),
+            GpioPattern(pins={26: False, 27: False}, delay_after=0.1),
+            GpioPattern(pins={26: True,  27: False}, delay_after=0.1),
+            GpioPattern(pins={26: True,  27: True},  delay_after=0.0),
+        ]
+    ),
+    ResetTarget.SLZB07: GpioResetConfig(
+        chip=None,
+        chip_type="cp210x",
+        pattern=[
+            GpioPattern(pins={4: True,  5: True},  delay_after=0.1),
+            GpioPattern(pins={4: False, 5: False}, delay_after=0.1),
+            GpioPattern(pins={4: True,  5: False}, delay_after=0.1),
+            GpioPattern(pins={4: True,  5: True},  delay_after=0.0),
+        ]
+    ),
+    ResetTarget.RTS_DTR: GpioResetConfig(
+        chip=None,
+        chip_type="uart",
+        pattern=[
+            GpioPattern(pins={"dtr": False, "rts": True},  delay_after=0.1),
+            GpioPattern(pins={"dtr": True,  "rts": False}, delay_after=0.5),
+            GpioPattern(pins={"dtr": False, "rts": False}, delay_after=0.0),
+        ]
+    ),
 }
+# fmt: on
+
+GPIO_CONFIGS[ResetTarget.SONOFF] = GPIO_CONFIGS[ResetTarget.RTS_DTR]

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -55,9 +55,6 @@ class ResetTarget(enum.Enum):
     SLZB07 = "slzb07"
     RTS_DTR = "rts_dtr"
 
-    # Deprecated alias for `RTS_DTR`
-    SONOFF = "sonoff"
-
 
 @dataclasses.dataclass
 class GpioPattern:
@@ -115,5 +112,3 @@ GPIO_CONFIGS = {
     ),
 }
 # fmt: on
-
-GPIO_CONFIGS[ResetTarget.SONOFF] = GPIO_CONFIGS[ResetTarget.RTS_DTR]

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -144,7 +144,7 @@ class SerialPort(click.ParamType):
 )
 @click.option(
     "--bootloader-reset",
-    type=click.Choice([t.value for t in ResetTarget]),
+    type=click.Choice([t.value for t in ResetTarget if t != ResetTarget.SONOFF]),
 )
 @click.pass_context
 def main(
@@ -339,7 +339,7 @@ async def flash(
         flasher._reset_target = ResetTarget.YELLOW
         _LOGGER.info(reset_msg, "--yellow-gpio-reset")
     elif sonoff_reset:
-        flasher._reset_target = ResetTarget.SONOFF
+        flasher._reset_target = ResetTarget.RTS_DTR
         _LOGGER.info(reset_msg, "--sonoff-reset")
 
     try:

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -144,7 +144,7 @@ class SerialPort(click.ParamType):
 )
 @click.option(
     "--bootloader-reset",
-    type=click.Choice([t.value for t in ResetTarget if t != ResetTarget.SONOFF]),
+    type=click.Choice([t.value for t in ResetTarget] + ["sonoff"]),
 )
 @click.pass_context
 def main(
@@ -188,6 +188,13 @@ def main(
         # Replicate the "Error: Missing option" traceback
         param = next(p for p in ctx.command.params if p.name == "device")
         raise click.MissingParameter(ctx=ctx, param=param)
+
+    if bootloader_reset == "sonoff":
+        _LOGGER.warning(
+            "The 'sonoff' reset target is deprecated."
+            " Use '--bootloader-reset rts_dtr' instead."
+        )
+        bootloader_reset = ResetTarget.RTS_DTR.value
 
     ctx.obj = {
         "verbosity": verbose,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -8,7 +8,7 @@ import typing
 import bellows.config
 import bellows.ezsp
 import bellows.types
-from zigpy.serial import SerialProtocol
+from zigpy.serial import FlowControlSerialProtocol
 import zigpy.types
 
 from .common import (
@@ -86,15 +86,14 @@ class Flasher:
 
     async def enter_serial_bootloader(self):
         baudrate = self._baudrates[ApplicationType.GECKO_BOOTLOADER][0]
-        async with connect_protocol(self._device, baudrate, SerialProtocol) as sonoff:
-            serial = sonoff._transport.serial
-            serial.dtr = False
-            serial.rts = True
+        async with connect_protocol(
+            self._device, baudrate, FlowControlSerialProtocol
+        ) as sonoff:
+            await sonoff.set_flow_control(dtr=False, rts=True)
             await asyncio.sleep(0.1)
-            serial.dtr = True
-            serial.rts = False
+            await sonoff.set_flow_control(dtr=True, rts=False)
             await asyncio.sleep(0.5)
-            serial.dtr = False
+            await sonoff.set_flow_control(dtr=False, rts=False)
 
     def _connect_gecko_bootloader(self, baudrate: int):
         return connect_protocol(self._device, baudrate, GeckoBootloaderProtocol)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -68,32 +68,33 @@ class Flasher:
             ResetTarget(bootloader_reset) if bootloader_reset else None
         )
 
-    async def enter_bootloader_reset(self, target):
+    async def enter_bootloader_reset(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")
-        if target in GPIO_CONFIGS.keys():
-            config = GPIO_CONFIGS[target]
-            if "chip" not in config.keys():
-                _LOGGER.warning(
-                    f"When using {target.value} bootloader reset "
-                    + "ensure no other CP2102 USB serial devices are connected."
-                )
-                config["chip"] = await find_gpiochip_by_label(config["chip_name"])
-            await send_gpio_pattern(
-                config["chip"], config["pin_states"], config["toggle_delay"]
-            )
-        else:
-            await self.enter_serial_bootloader()
 
-    async def enter_serial_bootloader(self):
-        baudrate = self._baudrates[ApplicationType.GECKO_BOOTLOADER][0]
-        async with connect_protocol(
-            self._device, baudrate, FlowControlSerialProtocol
-        ) as sonoff:
-            await sonoff.set_flow_control(dtr=False, rts=True)
-            await asyncio.sleep(0.1)
-            await sonoff.set_flow_control(dtr=True, rts=False)
-            await asyncio.sleep(0.5)
-            await sonoff.set_flow_control(dtr=False, rts=False)
+        config = GPIO_CONFIGS[target]
+        chip = config.chip
+
+        if config.chip_type == "cp210x":
+            _LOGGER.warning(
+                "When using %s bootloader reset ensure no other CP2102 USB serial"
+                " devices are connected.",
+                target.value,
+            )
+
+            chip = await find_gpiochip_by_label(config.chip_type)
+
+        if config.chip_type == "uart":
+            # The baudrate isn't really necessary, since we're using flow control pins
+            baudrate = self._baudrates[ApplicationType.GECKO_BOOTLOADER][0]
+
+            async with connect_protocol(
+                self._device, baudrate, FlowControlSerialProtocol
+            ) as uart:
+                for pattern in config.pattern:
+                    await uart.set_signals(**pattern.pins)
+                    await asyncio.sleep(pattern.delay_after)
+        else:
+            await send_gpio_pattern(chip, config.pattern)
 
     def _connect_gecko_bootloader(self, baudrate: int):
         return connect_protocol(self._device, baudrate, GeckoBootloaderProtocol)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -8,11 +8,11 @@ import typing
 import bellows.config
 import bellows.ezsp
 import bellows.types
-from zigpy.serial import FlowControlSerialProtocol
 import zigpy.types
 
 from .common import (
     PROBE_TIMEOUT,
+    FlowControlSerialProtocol,
     Version,
     asyncio_timeout,
     connect_protocol,

--- a/universal_silabs_flasher/gpio.py
+++ b/universal_silabs_flasher/gpio.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from os import scandir
 import time
 import typing
 
 from .const import GpioPattern
+
+_LOGGER = logging.getLogger(__name__)
 
 try:
     import gpiod
@@ -31,11 +34,13 @@ elif is_gpiod_v1:
 
         try:
             # Open the pins and set their initial states
+            _LOGGER.debug("Sending GPIO pattern %r", pattern[0])
             lines.request(config, [int(v) for v in pattern[0].pins.values()])
             time.sleep(pattern[0].delay_after)
 
             # Send all subsequent states
             for p in pattern[1:]:
+                _LOGGER.debug("Sending GPIO pattern %r", p)
                 lines.set_values([int(v) for v in p.pins.values()])
                 time.sleep(p.delay_after)
         finally:
@@ -46,7 +51,8 @@ elif is_gpiod_v1:
 else:
     # gpiod >= 2.0.2
     def _send_gpio_pattern(chip: str, pattern: list[GpioPattern]) -> None:
-        # `gpiod` isn't available on Windows
+        _LOGGER.debug("Sending GPIO pattern %r", pattern[0])
+
         with gpiod.request_lines(
             path=chip,
             consumer="universal-silabs-flasher",
@@ -64,6 +70,7 @@ else:
             try:
                 # Send all subsequent states
                 for p in pattern[1:]:
+                    _LOGGER.debug("Sending GPIO pattern %r", p)
                     request.set_values(
                         {
                             pin: gpiod.line.Value(int(state))

--- a/universal_silabs_flasher/gpio.py
+++ b/universal_silabs_flasher/gpio.py
@@ -5,6 +5,8 @@ from os import scandir
 import time
 import typing
 
+from .const import GpioPattern
+
 try:
     import gpiod
 
@@ -14,20 +16,14 @@ except ImportError:
 
 if gpiod is None:
     # No gpiod library
-    def _send_gpio_pattern(
-        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
-    ) -> None:
+    def _send_gpio_pattern(chip: str, pattern: list[GpioPattern]) -> None:
         raise NotImplementedError("GPIO not supported on this platform")
 
 elif is_gpiod_v1:
     # gpiod <= 1.5.4
-    def _send_gpio_pattern(
-        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
-    ) -> None:
-        num_states = len(next(iter(pin_states.values())))
-
+    def _send_gpio_pattern(chip: str, pattern: list[GpioPattern]) -> None:
         chip = gpiod.chip(chip, gpiod.chip.OPEN_BY_PATH)
-        lines = chip.get_lines(pin_states.keys())
+        lines = chip.get_lines(pattern[0].pins.keys())
 
         config = gpiod.line_request()
         config.consumer = "universal-silabs-flasher"
@@ -35,12 +31,13 @@ elif is_gpiod_v1:
 
         try:
             # Open the pins and set their initial states
-            lines.request(config, [int(states[0]) for states in pin_states.values()])
+            lines.request(config, [int(v) for v in pattern[0].pins.values()])
+            time.sleep(pattern[0].delay_after)
 
             # Send all subsequent states
-            for i in range(1, num_states):
-                time.sleep(toggle_delay)
-                lines.set_values([int(states[i]) for states in pin_states.values()])
+            for p in pattern[1:]:
+                lines.set_values([int(v) for v in p.pins.values()])
+                time.sleep(p.delay_after)
         finally:
             # Clean up and ensure the GPIO pins are reset to inputs
             lines.set_direction_input()
@@ -48,12 +45,8 @@ elif is_gpiod_v1:
 
 else:
     # gpiod >= 2.0.2
-    def _send_gpio_pattern(
-        chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
-    ) -> None:
+    def _send_gpio_pattern(chip: str, pattern: list[GpioPattern]) -> None:
         # `gpiod` isn't available on Windows
-        num_states = len(next(iter(pin_states.values())))
-
         with gpiod.request_lines(
             path=chip,
             consumer="universal-silabs-flasher",
@@ -61,27 +54,29 @@ else:
                 # Set initial states
                 pin: gpiod.LineSettings(
                     direction=gpiod.line.Direction.OUTPUT,
-                    output_value=gpiod.line.Value(states[0]),
+                    output_value=gpiod.line.Value(state),
                 )
-                for pin, states in pin_states.items()
+                for pin, state in pattern[0].pins.items()
             },
         ) as request:
+            time.sleep(pattern[0].delay_after)
+
             try:
                 # Send all subsequent states
-                for i in range(1, num_states):
-                    time.sleep(toggle_delay)
+                for p in pattern[1:]:
                     request.set_values(
                         {
-                            pin: gpiod.line.Value(int(pin_states[pin][i]))
-                            for pin, states in pin_states.items()
+                            pin: gpiod.line.Value(int(state))
+                            for pin, state in p.pins.items()
                         }
                     )
+                    time.sleep(p.delay_after)
             finally:
                 # Clean up and ensure the GPIO pins are reset to inputs
                 request.reconfigure_lines(
                     {
                         pin: gpiod.LineSettings(direction=gpiod.line.Direction.INPUT)
-                        for pin, states in pin_states.items()
+                        for pin in pattern[0].pins.keys()
                     }
                 )
 
@@ -119,9 +114,7 @@ async def find_gpiochip_by_label(label: str) -> str:
     return result
 
 
-async def send_gpio_pattern(
-    chip: str, pin_states: dict[int, list[bool]], toggle_delay: float
-) -> None:
+async def send_gpio_pattern(chip: str, pattern: list[GpioPattern]) -> None:
     await asyncio.get_running_loop().run_in_executor(
-        None, _send_gpio_pattern, chip, pin_states, toggle_delay
+        None, _send_gpio_pattern, chip, pattern
     )


### PR DESCRIPTION
To allow other reset patterns to be used in the future (if needed) and to consolidate the GPIO logic, I've merged the GPIO and flow control bootloader reset patterns. This is in preparation for flow control in the web flasher: https://github.com/NabuCasa/sl-web-tools/pull/20
