### PR TITLE
Propagate errors during XMODEM transfer

### DIFF
--- a/universal_silabs_flasher/xmodemcrc.py
+++ b/universal_silabs_flasher/xmodemcrc.py
@@ -158,6 +158,11 @@ async def send_xmodem128_crc(
         # Reset the old protocol
         transport.set_protocol(old_protocol)
 
+        # Propagate the exception to our original protocol, in case the connection was
+        # closed
+        if reader.exception() is not None:
+            old_protocol.connection_lost(reader.exception())
+
         # Send our reader's buffer to the old protocol
         data = bytes(reader._buffer)
 


### PR DESCRIPTION
If a transfer is interrupted with an error during XMODEM transfer, us swapping the transport's protocol results in a deadlock: the transport is closed but the old protocol will never be sent a `connection_lost` event.

In a future PR, we should switch over to a state machine-based implementation to avoid these types of issues.