### PR TITLE
More reliable state waiting errors

### DIFF
--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -105,6 +105,11 @@ class StateMachine:
         for future in self._futures_for_state[state]:
             future.set_result(None)
 
+    def cancel_all_futures(self, exc: BaseException) -> None:
+        for futures in self._futures_for_state.values():
+            for future in futures:
+                future.set_exception(exc)
+
     async def wait_for_state(self, state: str, timeout: float = 30.0) -> None:
         """Waits for a state. Returns immediately if the state is active."""
         assert state in self._states

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -105,7 +105,7 @@ class StateMachine:
         for future in self._futures_for_state[state]:
             future.set_result(None)
 
-    async def wait_for_state(self, state: str) -> None:
+    async def wait_for_state(self, state: str, timeout: float = 30.0) -> None:
         """Waits for a state. Returns immediately if the state is active."""
         assert state in self._states
 
@@ -116,7 +116,8 @@ class StateMachine:
         self._futures_for_state[state].append(future)
 
         try:
-            return await future
+            async with asyncio_timeout(timeout):
+                return await future
         finally:
             # Always clean up the future
             self._futures_for_state[state].remove(future)

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -65,6 +65,12 @@ class GeckoBootloaderProtocol(SerialProtocol):
         self._version: str | None = None
         self._upload_status: str | None = None
 
+    def connection_lost(self, exc: Exception | None) -> None:
+        super().connection_lost(exc)
+        self._state_machine.cancel_all_futures(
+            exc or RuntimeError("Connection has been lost")
+        )
+
     async def probe(self) -> Version:
         """Attempt to communicate with the bootloader."""
         async with asyncio_timeout(PROBE_TIMEOUT):


### PR DESCRIPTION
Currently, we can run into issues when the connection is lost during bootloader communication. This is mitigated by cancelling all state machine waiters in the event of an error and also introducing a global timeout to the amount of time a state can be waited for.