### PR TITLE
Fix CPC parsing deadlock

### DIFF
--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -300,10 +300,12 @@ class CPCProtocol(SerialProtocol):
                 flag = bytes([cpc_types.FLAG])
 
                 try:
-                    self._buffer = self._buffer[self._buffer.index(flag) :]
+                    flag_index = self._buffer.index(flag, 1)
                 except ValueError:
                     self._buffer.clear()
                     break
+                else:
+                    self._buffer = self._buffer[flag_index:]
             else:
                 self.frame_received(frame)
 


### PR DESCRIPTION
We need to skip the flag byte when parsing. Otherwise, CPC parsing will loop endlessly.