### PR TITLE
Allow factory resetting EmberZNet from the flasher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Usage: universal-silabs-flasher [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -v, --verbose
-  --device PATH_OR_URL           [required]
-  --bootloader-baudrate NUMBERS  [default: 115200]
-  --cpc-baudrate NUMBERS         [default: 460800, 115200, 230400]
-  --ezsp-baudrate NUMBERS        [default: 115200]
+  --device PATH_OR_URL
+  --bootloader-baudrate NUMBERS   [default: 115200]
+  --cpc-baudrate NUMBERS          [default: 460800, 115200, 230400]
+  --ezsp-baudrate NUMBERS         [default: 115200]
   --router-baudrate NUMBERS       [default: 115200]
   --spinel-baudrate NUMBERS       [default: 460800]
   --probe-method TEXT             [default: bootloader, cpc, ezsp, spinel,
                                   router]
-  --bootloader-reset [yellow|ihost|slzb07|sonoff]
-  --help                         Show this message and exit.
+  --bootloader-reset [yellow|ihost|slzb07|rts_dtr|sonoff]
+  --help                          Show this message and exit.
 
 Commands:
   dump-gbl-metadata
@@ -63,19 +63,13 @@ $ universal-silabs-flasher \
 ```
 
 
-## Writing IEEE address
-Ensure a target device running EmberZNet firmware has the correct node IEEE address:
+## Resetting EZSP after flashing
+Factory reset a Zigbee adapter after upgrading the Zigbee firmware:
 
 ```bash
 $ universal-silabs-flasher \
     --device /dev/cu.SLAB_USBtoUART \
-    write-ieee \
-    --ieee 00:3c:84:ff:fe:92:bb:2c
+    flash \
+    --firmware NabuCasa_SkyConnect_EZSP_v7.1.3.0_ncp-uart-hw_115200.gbl \
+    --ezsp-factory-reset
 ```
-
-The IEEE address can also be specified without colons: `--ieee 003c84fffe92bb2c`.
-
-If the current device's IEEE address already matches the provided one, the command will not write it unnecessarily.
-Depending on firmware version, writing the IEEE address can be a **permanent** operation. If this is the case,
-you will need to upgrade the firmware on your adapter to a more recent release of EmberZNet or perform the one-time
-write with `--force`.

--- a/universal_silabs_flasher/emberznet.py
+++ b/universal_silabs_flasher/emberznet.py
@@ -39,8 +39,6 @@ async def connect_ezsp_application(
     """Context manager to return a connected EZSP instance for a serial port."""
 
     app = bellows.zigbee.application.ControllerApplication(
-        # We use this roundabout way to construct the device schema to make sure that
-        # we are compatible with future changes to the zigpy device config schema.
         {
             bellows.config.CONF_USE_THREAD: False,
             zigpy.config.CONF_DEVICE: {

--- a/universal_silabs_flasher/emberznet.py
+++ b/universal_silabs_flasher/emberznet.py
@@ -30,3 +30,29 @@ async def connect_ezsp(port: str, baudrate: int = 115200) -> bellows.ezsp.EZSP:
         yield ezsp
     finally:
         await ezsp.disconnect()
+
+
+@contextlib.asynccontextmanager
+async def connect_ezsp_application(
+    port: str, baudrate: int = 115200
+) -> bellows.zigbee.application.ControllerApplication:
+    """Context manager to return a connected EZSP instance for a serial port."""
+
+    app = bellows.zigbee.application.ControllerApplication(
+        # We use this roundabout way to construct the device schema to make sure that
+        # we are compatible with future changes to the zigpy device config schema.
+        {
+            bellows.config.CONF_USE_THREAD: False,
+            zigpy.config.CONF_DEVICE: {
+                zigpy.config.CONF_DEVICE_PATH: port,
+                zigpy.config.CONF_DEVICE_BAUDRATE: baudrate,
+            },
+        }
+    )
+
+    await app.connect()
+
+    try:
+        yield app
+    finally:
+        await app.disconnect()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -279,6 +279,7 @@ async def write_ieee(ctx: click.Context, ieee: zigpy.types.EUI64, force: bool) -
 @click.option("--allow-cross-flashing", is_flag=True, default=False, show_default=True)
 @click.option("--yellow-gpio-reset", is_flag=True, default=False, show_default=True)
 @click.option("--sonoff-reset", is_flag=True, default=False, show_default=True)
+@click.option("--ezsp-factory-reset", is_flag=True, default=False, show_default=True)
 @click.pass_context
 @click_coroutine
 async def flash(
@@ -290,6 +291,7 @@ async def flash(
     allow_cross_flashing: bool,
     yellow_gpio_reset: bool,
     sonoff_reset: bool,
+    ezsp_factory_reset: bool,
 ) -> None:
     flasher = ctx.obj["flasher"]
 
@@ -444,3 +446,7 @@ async def flash(
                 "Firmware image was rejected by the device. Ensure this is the correct"
                 " image for this device."
             )
+
+    if ezsp_factory_reset:
+        _LOGGER.info("Factory resetting the stick")
+        await flasher.emberznet_factory_reset()

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -20,7 +20,7 @@ from .common import (
 )
 from .const import DEFAULT_BAUDRATES, GPIO_CONFIGS, ApplicationType, ResetTarget
 from .cpc import CPCProtocol
-from .emberznet import connect_ezsp
+from .emberznet import connect_ezsp, connect_ezsp_application
 from .firmware import FirmwareImage
 from .gecko_bootloader import GeckoBootloaderProtocol, NoFirmwareError
 from .gpio import find_gpiochip_by_label, send_gpio_pattern
@@ -104,6 +104,9 @@ class Flasher:
 
     def _connect_ezsp(self, baudrate: int):
         return connect_ezsp(self._device, baudrate)
+
+    def _connect_ezsp_app(self, baudrate: int):
+        return connect_ezsp_application(self._device, baudrate)
 
     def _connect_router(self, baudrate: int):
         return connect_protocol(self._device, baudrate, RouterProtocol)
@@ -360,3 +363,7 @@ class Flasher:
             _LOGGER.info("Wrote new device IEEE: %s", new_ieee)
 
         return True
+
+    async def emberznet_factory_reset(self) -> None:
+        async with self._connect_ezsp_app(self.app_baudrate) as app:
+            await app.reset_network_info()


### PR DESCRIPTION
Useful to upgrade a stick's firmware and reset it to a known-good state in one command.