### PR TITLE
Allow arbitrary Geck Bootloader menu items

### DIFF
--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -30,6 +30,7 @@ MENU_REGEX = re.compile(
     rb"1\. upload (?:gbl|ebl)\r\n"
     rb"2\. run\r\n"
     rb"3\. ebl info\r\n"
+    rb"(\d+\. \w+\r\n)*"  # All other options are ignored but we still expect a menu
     rb"BL > "
 )
 

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -30,7 +30,7 @@ MENU_REGEX = re.compile(
     rb"1\. upload (?:gbl|ebl)\r\n"
     rb"2\. run\r\n"
     rb"3\. ebl info\r\n"
-    rb"(\d+\. \w+\r\n)*"  # All other options are ignored but we still expect a menu
+    rb"(\d+\. .*?\r\n)*"  # All other options are ignored but we still expect a menu
     rb"BL > "
 )
 


### PR DESCRIPTION
This will allow USF to communicate with nonstandard Gecko Bootloader implementations that have added extra menu items.