### PR TITLE
Implement the baudrate bootloader trigger

### DIFF
--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -1,7 +1,8 @@
 import click
 import pytest
 
-from universal_silabs_flasher.flash import SerialPort
+from universal_silabs_flasher.const import ResetTarget
+from universal_silabs_flasher.flash import EnumWithSeparator, SerialPort
 
 
 def test_click_serialport_validation():
@@ -22,3 +23,26 @@ def test_click_serialport_validation():
         assert SerialPort().convert("/dev/serial/by-id/does-not-exist", None, None)
 
     assert "does not exist" in exc_info.value.message
+
+
+def test_enum_with_separator_single_value() -> None:
+    converter = EnumWithSeparator(ResetTarget)
+    result = converter.convert("rts_dtr", None, None)
+    assert result == [ResetTarget.RTS_DTR]
+
+
+def test_enum_with_separator_multiple_values() -> None:
+    converter = EnumWithSeparator(ResetTarget)
+    result = converter.convert("rts_dtr,baudrate", None, None)
+    assert result == [ResetTarget.RTS_DTR, ResetTarget.BAUDRATE]
+
+
+def test_enum_with_separator_invalid_value() -> None:
+    converter = EnumWithSeparator(ResetTarget)
+
+    with pytest.raises(click.BadParameter) as exc_info:
+        converter.convert("invalid_target", None, None)
+
+    assert "'invalid_target' is invalid, must be one of:" in str(exc_info.value)
+    assert "yellow" in str(exc_info.value)
+    assert "rts_dtr" in str(exc_info.value)

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -3,8 +3,9 @@ from unittest.mock import MagicMock, call, patch
 
 import zigpy.types as t
 
-from universal_silabs_flasher.common import Version
+from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
 from universal_silabs_flasher.flasher import Flasher, ProbeResult
+from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
 
 async def test_write_emberznet_eui64():
@@ -50,14 +51,22 @@ async def test_baudrate_reset_pattern():
         await flasher.trigger_bootloader_reset()
 
     assert mock_connect_protocol.mock_calls == [
-        call("/dev/ttyMOCK", 150, mock_connect_protocol.call_args.args[2]),
+        # Connect with 150 baud
+        call("/dev/ttyMOCK", 150, FlowControlSerialProtocol),
         call().__aenter__(),
         call().__aexit__(None, None, None),
-        call("/dev/ttyMOCK", 300, mock_connect_protocol.call_args.args[2]),
+        # Connect with 300 baud
+        call("/dev/ttyMOCK", 300, FlowControlSerialProtocol),
         call().__aenter__(),
         call().__aexit__(None, None, None),
-        call("/dev/ttyMOCK", 600, mock_connect_protocol.call_args.args[2]),
+        # Connect with 600 baud
+        call("/dev/ttyMOCK", 600, FlowControlSerialProtocol),
         call().__aenter__(),
         call().__aenter__()._transport.write(b"BZ"),
+        call().__aexit__(None, None, None),
+        # Probe
+        call("/dev/ttyMOCK", 115200, GeckoBootloaderProtocol),
+        call().__aenter__(),
+        call().__aenter__().probe(),
         call().__aexit__(None, None, None),
     ]

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, call, patch
 import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
-from universal_silabs_flasher.const import ResetTarget
+from universal_silabs_flasher.const import ApplicationType, ResetTarget
 from universal_silabs_flasher.flasher import Flasher, ProbeResult
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
@@ -170,3 +170,37 @@ async def test_trigger_bootloader_reset_all_probes_fail():
         call(run_firmware=False, baudrate=115200),
         call(run_firmware=False, baudrate=115200),
     ]
+
+
+async def test_probe_app_type_fallback_to_bootloader() -> None:
+    flasher = Flasher(device="/dev/ttyMOCK", bootloader_reset=(ResetTarget.RTS_DTR,))
+
+    bootloader_result = ProbeResult(
+        version=Version("1.0.0"),
+        continue_probing=False,
+        baudrate=115200,
+    )
+
+    with (
+        patch.object(
+            flasher, "trigger_bootloader_reset", return_value=bootloader_result
+        ) as mock_trigger_reset,
+        patch.object(
+            flasher, "probe_gecko_bootloader", side_effect=asyncio.TimeoutError
+        ),
+        patch.object(flasher, "probe_cpc", side_effect=asyncio.TimeoutError),
+        patch.object(flasher, "probe_ezsp", side_effect=asyncio.TimeoutError),
+        patch.object(flasher, "probe_router", side_effect=asyncio.TimeoutError),
+        patch.object(flasher, "probe_spinel", side_effect=asyncio.TimeoutError),
+    ):
+        await flasher.probe_app_type()
+
+    # Should fallback to bootloader when no valid application found
+    assert flasher.app_type == ApplicationType.GECKO_BOOTLOADER
+    assert flasher.app_version == Version("1.0.0")
+    assert flasher.app_baudrate == 115200
+    assert flasher.bootloader_baudrate == 115200
+
+    # trigger_bootloader_reset should be called twice - once at start and once
+    # for fallback
+    assert mock_trigger_reset.call_count == 2

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
+from universal_silabs_flasher.const import ResetTarget
 from universal_silabs_flasher.flasher import Flasher, ProbeResult
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
@@ -69,4 +70,103 @@ async def test_baudrate_reset_pattern():
         call().__aenter__(),
         call().__aenter__().probe(),
         call().__aexit__(None, None, None),
+    ]
+
+
+async def test_trigger_bootloader_reset_first_probe_succeeds():
+    flasher = Flasher(
+        device="/dev/ttyMOCK",
+        bootloader_reset=(ResetTarget.RTS_DTR, ResetTarget.BAUDRATE),
+    )
+
+    with (
+        patch.object(flasher, "trigger_bootloader") as mock_trigger,
+        patch.object(
+            flasher,
+            "probe_gecko_bootloader",
+            return_value=ProbeResult(
+                version=Version("1.0.0"),
+                continue_probing=False,
+                baudrate=115200,
+            ),
+        ) as mock_probe,
+    ):
+        result = await flasher.trigger_bootloader_reset()
+
+    assert result is not None
+    assert result.version == Version("1.0.0")
+    assert result.baudrate == 115200
+
+    # Only first reset target should be attempted
+    assert mock_trigger.mock_calls == [call(ResetTarget.RTS_DTR)]
+    # Only one probe attempt for the first reset target
+    assert mock_probe.mock_calls == [call(run_firmware=False, baudrate=115200)]
+
+
+async def test_trigger_bootloader_reset_second_probe_succeeds():
+    flasher = Flasher(
+        device="/dev/ttyMOCK",
+        bootloader_reset=(ResetTarget.RTS_DTR, ResetTarget.BAUDRATE),
+    )
+
+    with (
+        patch.object(flasher, "trigger_bootloader") as mock_trigger,
+        patch.object(
+            flasher,
+            "probe_gecko_bootloader",
+            side_effect=[
+                asyncio.TimeoutError,  # First reset target fails
+                ProbeResult(  # Second reset target succeeds
+                    version=Version("1.0.0"),
+                    continue_probing=False,
+                    baudrate=115200,
+                ),
+            ],
+        ) as mock_probe,
+    ):
+        result = await flasher.trigger_bootloader_reset()
+
+    assert result is not None
+    assert result.version == Version("1.0.0")
+    assert result.baudrate == 115200
+
+    # Both reset targets should be attempted
+    assert mock_trigger.mock_calls == [
+        call(ResetTarget.RTS_DTR),
+        call(ResetTarget.BAUDRATE),
+    ]
+    # Two probe attempts - one for each reset target
+    assert mock_probe.mock_calls == [
+        call(run_firmware=False, baudrate=115200),
+        call(run_firmware=False, baudrate=115200),
+    ]
+
+
+async def test_trigger_bootloader_reset_all_probes_fail():
+    flasher = Flasher(
+        device="/dev/ttyMOCK",
+        bootloader_reset=(ResetTarget.RTS_DTR, ResetTarget.BAUDRATE),
+    )
+
+    with (
+        patch.object(flasher, "trigger_bootloader") as mock_trigger,
+        patch.object(
+            flasher,
+            "probe_gecko_bootloader",
+            side_effect=asyncio.TimeoutError,  # All probes fail
+        ) as mock_probe,
+    ):
+        result = await flasher.trigger_bootloader_reset()
+
+    assert result is None
+
+    # Both reset targets should be attempted
+    assert mock_trigger.mock_calls == [
+        call(ResetTarget.RTS_DTR),
+        call(ResetTarget.BAUDRATE),
+    ]
+    # Two probe attempts - one for each reset target
+    assert mock_probe.mock_calls == [
+        call(run_firmware=False, baudrate=115200),
+        call(run_firmware=False, baudrate=115200),
     ]

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import zigpy.types as t
 
@@ -36,4 +36,28 @@ async def test_write_emberznet_eui64():
 
     assert ezsp.write_custom_eui64.mock_calls == [
         call(ieee=t.EUI64.convert("11:22:33:44:55:66:77:88"), burn_into_userdata=True)
+    ]
+
+
+async def test_baudrate_reset_pattern():
+    flasher = Flasher(device="/dev/ttyMOCK", bootloader_reset="baudrate")
+
+    with patch(
+        "universal_silabs_flasher.flasher.connect_protocol"
+    ) as mock_connect_protocol:
+        mock_uart = mock_connect_protocol.return_value.__aenter__.return_value
+        mock_uart._transport.write = MagicMock()
+        await flasher.trigger_bootloader_reset()
+
+    assert mock_connect_protocol.mock_calls == [
+        call("/dev/ttyMOCK", 150, mock_connect_protocol.call_args.args[2]),
+        call().__aenter__(),
+        call().__aexit__(None, None, None),
+        call("/dev/ttyMOCK", 300, mock_connect_protocol.call_args.args[2]),
+        call().__aenter__(),
+        call().__aexit__(None, None, None),
+        call("/dev/ttyMOCK", 600, mock_connect_protocol.call_args.args[2]),
+        call().__aenter__(),
+        call().__aenter__()._transport.write(b"BZ"),
+        call().__aexit__(None, None, None),
     ]

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -56,6 +56,7 @@ class ResetTarget(enum.Enum):
     IHOST = "ihost"
     SLZB07 = "slzb07"
     RTS_DTR = "rts_dtr"
+    BAUDRATE = "baudrate"
 
 
 @dataclasses.dataclass

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -56,7 +56,7 @@ class ResetTarget(enum.Enum):
     IHOST = "ihost"
     SLZB07 = "slzb07"
     RTS_DTR = "rts_dtr"
-    BAUDRATE_COMMAND = "baudrate_command"
+    BAUDRATE = "baudrate"
 
 
 @dataclasses.dataclass
@@ -113,6 +113,6 @@ GPIO_CONFIGS = {
             GpioPattern(pins={"dtr": False, "rts": False}, delay_after=0.0),
         ]
     ),
-    # ResetTarget.BAUDRATE_COMMAND is handled separately
+    # ResetTarget.BAUDRATE is handled separately
 }
 # fmt: on

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -56,7 +56,7 @@ class ResetTarget(enum.Enum):
     IHOST = "ihost"
     SLZB07 = "slzb07"
     RTS_DTR = "rts_dtr"
-    BAUDRATE = "baudrate"
+    BAUDRATE_COMMAND = "baudrate_command"
 
 
 @dataclasses.dataclass
@@ -113,5 +113,6 @@ GPIO_CONFIGS = {
             GpioPattern(pins={"dtr": False, "rts": False}, delay_after=0.0),
         ]
     ),
+    # ResetTarget.BAUDRATE_COMMAND is handled separately
 }
 # fmt: on

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -63,6 +63,33 @@ def click_enum_validator_factory(
     return validator_callback
 
 
+class EnumWithSeparator(click.ParamType):
+    """Click validator that accepts enum values separated by plus signs."""
+
+    name = "enum_with_separator"
+
+    def __init__(self, enum_cls: type[enum.Enum], separator: str = ",") -> None:
+        self._enum_cls = enum_cls
+        self._separator = separator
+
+    def convert(self, value: str, param: click.Parameter, ctx: click.Context) -> list:
+        values = value.split(self._separator)
+        enums = []
+
+        for v in values:
+            try:
+                enums.append(self._enum_cls(v))
+            except ValueError:
+                expected = [m.value for m in self._enum_cls]
+                self.fail(
+                    f"{v!r} is invalid, must be one of: {', '.join(expected)}",
+                    param,
+                    ctx,
+                )
+
+        return enums
+
+
 class SerialPort(click.ParamType):
     """Click validator that accepts serial ports."""
 
@@ -144,7 +171,13 @@ class SerialPort(click.ParamType):
 )
 @click.option(
     "--bootloader-reset",
-    type=click.Choice([t.value for t in ResetTarget] + ["sonoff"]),
+    default=[],
+    type=EnumWithSeparator(ResetTarget),
+    help=(
+        f"Reset methods to attempt when triggering bootloader mode. Multiple methods"
+        f" can be chained by separating them with a comma. Valid values: "
+        f" {', '.join([m.value for m in ResetTarget])}"
+    ),
 )
 @click.pass_context
 def main(
@@ -158,7 +191,7 @@ def main(
     router_baudrate: list[int],
     spinel_baudrate: list[int],
     probe_method: list[ApplicationType],
-    bootloader_reset: str | None,
+    bootloader_reset: list[ResetTarget],
 ) -> None:
     coloredlogs.install(
         fmt=(
@@ -189,13 +222,6 @@ def main(
         param = next(p for p in ctx.command.params if p.name == "device")
         raise click.MissingParameter(ctx=ctx, param=param)
 
-    if bootloader_reset == "sonoff":
-        _LOGGER.warning(
-            "The 'sonoff' reset target is deprecated."
-            " Use '--bootloader-reset rts_dtr' instead."
-        )
-        bootloader_reset = ResetTarget.RTS_DTR.value
-
     ctx.obj = {
         "verbosity": verbose,
         "flasher": Flasher(
@@ -208,7 +234,7 @@ def main(
                 ApplicationType.SPINEL: spinel_baudrate,
             },
             probe_methods=probe_method,
-            bootloader_reset=bootloader_reset,
+            bootloader_reset=tuple(bootloader_reset),
         ),
     }
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -31,6 +31,7 @@ from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE
 _LOGGER = logging.getLogger(__name__)
 
 EZSP_BOOTLOADER_LAUNCH_DELAY = 5
+BAUDRATE_BOOTLOADER_TRIGGER_PATTERN = (150, 300, 600)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -70,6 +71,17 @@ class Flasher:
 
     async def enter_bootloader_reset(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")
+
+        if target == ResetTarget.BAUDRATE:
+            for baudrate in BAUDRATE_BOOTLOADER_TRIGGER_PATTERN:
+                async with connect_protocol(
+                    self._device, baudrate, FlowControlSerialProtocol
+                ) as uart:
+                    await asyncio.sleep(0.1)
+
+            await asyncio.sleep(0.5)
+
+            return
 
         config = GPIO_CONFIGS[target]
         chip = config.chip

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -31,7 +31,6 @@ from .xmodemcrc import BLOCK_SIZE as XMODEM_BLOCK_SIZE
 _LOGGER = logging.getLogger(__name__)
 
 EZSP_BOOTLOADER_LAUNCH_DELAY = 5
-BAUDRATE_BOOTLOADER_TRIGGER_PATTERN = (150, 300, 600)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -72,12 +71,26 @@ class Flasher:
     async def enter_bootloader_reset(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")
 
-        if target == ResetTarget.BAUDRATE:
-            for baudrate in BAUDRATE_BOOTLOADER_TRIGGER_PATTERN:
-                async with connect_protocol(
-                    self._device, baudrate, FlowControlSerialProtocol
-                ) as uart:
-                    await asyncio.sleep(0.1)
+        if target == ResetTarget.BAUDRATE_COMMAND:
+            # Baudrate command mode uses a pattern of baudrates to enter a command mode:
+            # open the serial port with 150 baud, 300 baud, and 600 baud, writing AT
+            # commands to enter the bootloader.
+            async with connect_protocol(
+                self._device, 150, FlowControlSerialProtocol
+            ) as uart:
+                await asyncio.sleep(0.1)
+
+            async with connect_protocol(
+                self._device, 300, FlowControlSerialProtocol
+            ) as uart:
+                await asyncio.sleep(0.1)
+
+            async with connect_protocol(
+                self._device, 600, FlowControlSerialProtocol
+            ) as uart:
+                await asyncio.sleep(0.1)
+
+                uart._transport.write(b"BZ")
 
             await asyncio.sleep(0.5)
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -53,7 +53,7 @@ class Flasher:
             ApplicationType.SPINEL,
         ),
         device: str,
-        bootloader_reset: str | None = None,
+        bootloader_reset: str | tuple[ResetTarget, ...] = (),
     ):
         self._baudrates = baudrates
         self._probe_methods = probe_methods
@@ -64,16 +64,14 @@ class Flasher:
         self.app_baudrate: int | None = None
         self.bootloader_baudrate: int | None = None
 
-        self._reset_targets: list[ResetTarget] = []
+        if isinstance(bootloader_reset, str):
+            bootloader_reset = (ResetTarget(bootloader_reset),)
 
-        # Allow for multiple reset methods to be chained
-        if bootloader_reset:
-            for target in bootloader_reset.split("+"):
-                self._reset_targets.append(ResetTarget(target))
+        self._reset_targets: list[ResetTarget] = [
+            ResetTarget(target) for target in bootloader_reset if target
+        ]
 
     async def trigger_bootloader(self, target: ResetTarget) -> None:
-        _LOGGER.info(f"Triggering {target.value} bootloader")
-
         if target == ResetTarget.BAUDRATE:
             # Baudrate command mode uses a pattern of baudrates to enter a command mode:
             # open the serial port with 150 baud, 300 baud, and 600 baud, writing AT
@@ -203,9 +201,27 @@ class Flasher:
             continue_probing=False,
         )
 
-    async def trigger_bootloader_reset(self) -> None:
+    async def trigger_bootloader_reset(self) -> ProbeResult | None:
+        """Reset into the bootloader by trying the probing methods, one by one."""
+
         for target in self._reset_targets:
+            _LOGGER.info(f"Triggering {target.value} bootloader")
             await self.trigger_bootloader(target)
+
+            for baudrate in self._baudrates[ApplicationType.GECKO_BOOTLOADER]:
+                try:
+                    probe_result = await self.probe_gecko_bootloader(
+                        run_firmware=False, baudrate=baudrate
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                else:
+                    _LOGGER.info(
+                        f"Successfully entered bootloader using {target.value} reset"
+                    )
+                    return probe_result
+
+        return None
 
     async def probe_app_type(
         self,
@@ -222,11 +238,6 @@ class Flasher:
         )
         # fmt: on
 
-        # Reset into bootloader, if possible
-        await self.trigger_bootloader_reset()
-
-        bootloader_probe = None
-
         # Only run firmware from the bootloader if we have bootloader reset and
         # other probe methods
         only_probe_bootloader = types == [ApplicationType.GECKO_BOOTLOADER]
@@ -242,6 +253,9 @@ class Flasher:
             ApplicationType.SPINEL: self.probe_spinel,
             ApplicationType.ROUTER: self.probe_router,
         }
+
+        # Reset into bootloader, if possible
+        bootloader_probe = await self.trigger_bootloader_reset()
 
         for probe_method, baudrate in (
             (m, b) for m in types for b in self._baudrates[m]

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -64,11 +64,13 @@ class Flasher:
         self.app_baudrate: int | None = None
         self.bootloader_baudrate: int | None = None
 
-        self._reset_target: ResetTarget | None = (
-            ResetTarget(bootloader_reset) if bootloader_reset else None
-        )
+        self._reset_targets: list[ResetTarget] = []
 
-    async def enter_bootloader_reset(self, target: ResetTarget) -> None:
+        # Allow for multiple reset methods to be chained
+        for target in (bootloader_reset or "").split("+"):
+            self._reset_targets.append(ResetTarget(target))
+
+    async def trigger_bootloader(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")
 
         if target == ResetTarget.BAUDRATE_COMMAND:
@@ -200,6 +202,10 @@ class Flasher:
             continue_probing=False,
         )
 
+    async def trigger_bootloader_reset(self) -> None:
+        for target in self._reset_targets:
+            await self.trigger_bootloader(target)
+
     async def probe_app_type(
         self,
         types: typing.Iterable[ApplicationType] | None = None,
@@ -215,16 +221,15 @@ class Flasher:
         )
         # fmt: on
 
-        # Reset into bootloader
-        if self._reset_target:
-            await self.enter_bootloader_reset(self._reset_target)
+        # Reset into bootloader, if possible
+        await self.trigger_bootloader_reset()
 
         bootloader_probe = None
 
         # Only run firmware from the bootloader if we have bootloader reset and
         # other probe methods
         only_probe_bootloader = types == [ApplicationType.GECKO_BOOTLOADER]
-        run_firmware = self._reset_target and not only_probe_bootloader
+        run_firmware = self._reset_targets and not only_probe_bootloader
         probe_funcs = {
             ApplicationType.GECKO_BOOTLOADER: (
                 lambda baudrate: self.probe_gecko_bootloader(
@@ -271,10 +276,10 @@ class Flasher:
             self.app_baudrate = result.baudrate
             break
         else:
-            if bootloader_probe and self._reset_target:
+            if bootloader_probe and self._reset_targets:
                 # We have no valid application image but can still re-enter the
-                # bootloader
-                await self.enter_bootloader_reset(self._reset_target)
+                # bootloader whenever we want
+                await self.trigger_bootloader_reset()
 
                 self.app_type = ApplicationType.GECKO_BOOTLOADER
                 self.app_version = bootloader_probe.version

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -73,7 +73,7 @@ class Flasher:
     async def trigger_bootloader(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")
 
-        if target == ResetTarget.BAUDRATE_COMMAND:
+        if target == ResetTarget.BAUDRATE:
             # Baudrate command mode uses a pattern of baudrates to enter a command mode:
             # open the serial port with 150 baud, 300 baud, and 600 baud, writing AT
             # commands to enter the bootloader.

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -67,8 +67,9 @@ class Flasher:
         self._reset_targets: list[ResetTarget] = []
 
         # Allow for multiple reset methods to be chained
-        for target in (bootloader_reset or "").split("+"):
-            self._reset_targets.append(ResetTarget(target))
+        if bootloader_reset:
+            for target in bootloader_reset.split("+"):
+                self._reset_targets.append(ResetTarget(target))
 
     async def trigger_bootloader(self, target: ResetTarget) -> None:
         _LOGGER.info(f"Triggering {target.value} bootloader")


### PR DESCRIPTION
This PR implements an alternative bootloader trigger scheme: a pattern of baudrates and an AT command at the end.