### PR TITLE
Move CPC to end of probing list and add 460800 baud option to EZSP

### DIFF
--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -45,7 +45,7 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
 DEFAULT_BAUDRATES = {
     ApplicationType.GECKO_BOOTLOADER: [115200],
     ApplicationType.CPC: [460800, 115200, 230400],
-    ApplicationType.EZSP: [115200],
+    ApplicationType.EZSP: [115200, 460800],
     ApplicationType.SPINEL: [460800],
     ApplicationType.ROUTER: [115200],
 }

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -44,10 +44,10 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
 
 DEFAULT_BAUDRATES = {
     ApplicationType.GECKO_BOOTLOADER: [115200],
-    ApplicationType.CPC: [460800, 115200, 230400],
     ApplicationType.EZSP: [115200, 460800],
     ApplicationType.SPINEL: [460800],
     ApplicationType.ROUTER: [115200],
+    ApplicationType.CPC: [460800, 115200, 230400],
 }
 
 


### PR DESCRIPTION
CPC firmware is not commonly used these days.