### PR TITLE
Reset OpenThread on probe

### DIFF
--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -344,4 +344,4 @@ class SpinelProtocol(SerialProtocol):
                 )
         except asyncio.TimeoutError:
             # OTBR itself uses this logic, we match it
-            _LOGGER.warning("Device did not respond to reset, continuing")
+            _LOGGER.debug("Device did not respond to reset, continuing")

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -124,15 +124,17 @@ class SpinelProtocol(SerialProtocol):
     def data_received(self, data: bytes) -> None:
         super().data_received(data)
 
-        self._buffer = self._buffer.lstrip(bytes([HDLCSpecial.FLAG]))
-
-        if bytes([HDLCSpecial.FLAG]) not in self._buffer:
-            return
-
         while self._buffer:
-            # Flag bytes can come before and after any packet, any number of times
-            chunk, _, self._buffer = self._buffer.partition(bytes([HDLCSpecial.FLAG]))
+            chunk, flag, self._buffer = self._buffer.partition(
+                bytes([HDLCSpecial.FLAG])
+            )
 
+            # If the flag isn't found, we're done
+            if not flag:
+                self._buffer = chunk
+                break
+
+            # Sometimes the flag can be repeated multiple times
             if not chunk:
                 continue
 

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -22,6 +22,7 @@ from .spinel_types import (
 
 _LOGGER = logging.getLogger(__name__)
 
+COMMAND_TIMEOUT = 2
 RESET_TIMEOUT = 2
 
 
@@ -213,8 +214,8 @@ class SpinelProtocol(SerialProtocol):
         frame: SpinelFrame,
         *,
         wait_response: bool = True,
-        retries: int = 3,
-        timeout: float = 1,
+        retries: int = 2,
+        timeout: float = COMMAND_TIMEOUT,
         retry_delay: float = 0.1,
     ) -> SpinelFrame | None:
         # A transaction ID of `0` is special: we only use 1-15

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 import dataclasses
 import logging
 import typing
+from typing import callable
 
 from zigpy.serial import SerialProtocol
 import zigpy.types
 
 from .common import Version, asyncio_timeout, crc16_kermit
-from .spinel_types import CommandID, HDLCSpecial, PropertyID, ResetReason
+from .spinel_types import CommandID, HDLCSpecial, PackedUInt21, PropertyID, ResetReason
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,6 +112,9 @@ class SpinelProtocol(SerialProtocol):
         super().__init__()
         self._transaction_id: int = 1
         self._pending_frames: dict[int, asyncio.Future] = {}
+        self._property_listeners: defaultdict[PropertyID, list[callable]] = defaultdict(
+            list
+        )
 
     def send_data(self, data: bytes) -> None:
         assert self._transport is not None
@@ -154,6 +159,21 @@ class SpinelProtocol(SerialProtocol):
 
         if frame.header.transaction_id in self._pending_frames:
             self._pending_frames[frame.header.transaction_id].set_result(frame)
+
+        if frame.command_id == CommandID.PROP_VALUE_IS:
+            prop_id, data = PackedUInt21.deserialize(frame.data)
+            prop_id = PropertyID(prop_id)
+
+            for listener in self._property_listeners[prop_id]:
+                try:
+                    listener(data)
+                except Exception:
+                    _LOGGER.warning(
+                        "Error calling property listener for %r: %r",
+                        prop_id,
+                        listener,
+                        exc_info=True,
+                    )
 
     @typing.overload
     async def send_frame(
@@ -243,6 +263,35 @@ class SpinelProtocol(SerialProtocol):
         )
 
         return await self.send_frame(frame, **kwargs)
+
+    def add_property_listener(
+        self, property_id: PropertyID, callback: callable[[bytes], None]
+    ) -> None:
+        self._property_listeners[property_id].append(callback)
+
+    def remove_property_listener(
+        self, property_id: PropertyID, callback: callable[[bytes], None]
+    ) -> None:
+        self._property_listeners[property_id].remove(callback)
+
+    async def iter_property_changes(
+        self, property_id: PropertyID
+    ) -> typing.AsyncIterator:
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        try:
+            self.add_property_listener(property_id, queue.put_nowait)
+
+            while True:
+                item = await queue.get()
+                yield item
+        finally:
+            self.remove_property_listener(property_id, queue.put_nowait)
+
+    async def wait_for_property(self, property_id: PropertyID, value: bytes) -> None:
+        async for changed_value in self.iter_property_changes(property_id):
+            if changed_value == value:
+                return
 
     async def probe(self) -> Version:
         rsp = await self.send_command(

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import dataclasses
 import logging
 import typing
-from typing import callable
+from typing import Callable
 
 from zigpy.serial import SerialProtocol
 import zigpy.types
@@ -122,7 +122,7 @@ class SpinelProtocol(SerialProtocol):
         super().__init__()
         self._transaction_id: int = 1
         self._pending_frames: dict[int, asyncio.Future] = {}
-        self._property_listeners: defaultdict[PropertyID, list[callable]] = defaultdict(
+        self._property_listeners: defaultdict[PropertyID, list[Callable]] = defaultdict(
             list
         )
 
@@ -277,12 +277,12 @@ class SpinelProtocol(SerialProtocol):
         return await self.send_frame(frame, **kwargs)
 
     def add_property_listener(
-        self, property_id: PropertyID, callback: callable[[bytes], None]
+        self, property_id: PropertyID, callback: Callable[[bytes], None]
     ) -> None:
         self._property_listeners[property_id].append(callback)
 
     def remove_property_listener(
-        self, property_id: PropertyID, callback: callable[[bytes], None]
+        self, property_id: PropertyID, callback: Callable[[bytes], None]
     ) -> None:
         self._property_listeners[property_id].remove(callback)
 

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -11,9 +11,18 @@ from zigpy.serial import SerialProtocol
 import zigpy.types
 
 from .common import Version, asyncio_timeout, crc16_kermit
-from .spinel_types import CommandID, HDLCSpecial, PackedUInt21, PropertyID, ResetReason
+from .spinel_types import (
+    CommandID,
+    HDLCSpecial,
+    PackedUInt21,
+    PropertyID,
+    ResetReason,
+    Status,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+RESET_TIMEOUT = 2
 
 
 @dataclasses.dataclass(frozen=True)
@@ -296,6 +305,8 @@ class SpinelProtocol(SerialProtocol):
                 return
 
     async def probe(self) -> Version:
+        await self.reset(ResetReason.STACK)
+
         rsp = await self.send_command(
             CommandID.PROP_VALUE_GET,
             PropertyID.NCP_VERSION.serialize(),
@@ -313,8 +324,23 @@ class SpinelProtocol(SerialProtocol):
         return Version(short_version)
 
     async def enter_bootloader(self) -> None:
+        await self.reset(ResetReason.BOOTLOADER)
+
+    async def reset(self, reset_type: ResetReason) -> None:
         await self.send_command(
             CommandID.RESET,
-            ResetReason.BOOTLOADER.serialize(),
+            reset_type.serialize(),
             wait_response=False,
         )
+
+        if reset_type == ResetReason.BOOTLOADER:
+            return
+
+        try:
+            async with asyncio_timeout(RESET_TIMEOUT):
+                await self.wait_for_property(
+                    PropertyID.LAST_STATUS, Status.RESET_POWER_ON.serialize()
+                )
+        except asyncio.TimeoutError:
+            # OTBR itself uses this logic, we match it
+            _LOGGER.warning("Device did not respond to reset, continuing")

--- a/universal_silabs_flasher/spinel_types.py
+++ b/universal_silabs_flasher/spinel_types.py
@@ -218,3 +218,43 @@ class HDLCSpecial(enum.IntEnum):
     XON = 0x11
     XOFF = 0x13
     VENDOR = 0xF8
+
+
+class Status(zigpy.types.enum8):
+    OK = 0  # Operation has completed successfully.
+    FAILURE = 1  # Operation has failed for some undefined reason.
+    UNIMPLEMENTED = 2  # Given operation has not been implemented.
+    INVALID_ARGUMENT = 3  # An argument to the operation is invalid.
+    INVALID_STATE = 4  # This operation is invalid for the current device state.
+    INVALID_COMMAND = 5  # This command is not recognized.
+    INVALID_INTERFACE = 6  # This interface is not supported.
+    INTERNAL_ERROR = 7  # An internal runtime error has occurred.
+    SECURITY_ERROR = 8  # A security/authentication error has occurred.
+    PARSE_ERROR = 9  # A error has occurred while parsing the command.
+    IN_PROGRESS = 10  # This operation is in progress.
+    NOMEM = 11  # Operation prevented due to memory pressure.
+    BUSY = 12  # The device is currently performing a mutually exclusive operation
+    PROP_NOT_FOUND = 13  # The given property is not recognized.
+    DROPPED = 14  # A/The packet was dropped.
+    EMPTY = 15  # The result of the operation is empty.
+    CMD_TOO_BIG = 16  # The command was too large to fit in the internal buffer.
+    NO_ACK = 17  # The packet was not acknowledged.
+    CCA_FAILURE = 18  # The packet was not sent due to a CCA failure.
+    ALREADY = 19  # The operation is already in progress.
+    ITEM_NOT_FOUND = 20  # The given item could not be found.
+    INVALID_COMMAND_FOR_PROP = (
+        21  # The given command cannot be performed on this property.
+    )
+    UNKNOWN_NEIGHBOR = 22  # The neighbor is unknown.
+    NOT_CAPABLE = 23  # The target is not capable of handling requested operation.
+    RESPONSE_TIMEOUT = 24  # No response received from remote node
+
+    RESET_POWER_ON = 112
+    RESET_EXTERNAL = 113
+    RESET_SOFTWARE = 114
+    RESET_FAULT = 115
+    RESET_CRASH = 116
+    RESET_ASSERT = 117
+    RESET_OTHER = 118
+    RESET_UNKNOWN = 119
+    RESET_WATCHDOG = 120


### PR DESCRIPTION
To mirror the OTBR startup logic, we should reset the RCP firmware on connect.

May help with https://github.com/home-assistant/addons/issues/4210.