### PR TITLE
Migrate to probing explicit `app, baudrate` pairs in sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ timeout = 20
 log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -7,7 +7,11 @@ import click.core
 from click.testing import CliRunner
 import pytest
 
-from universal_silabs_flasher.const import ApplicationType, ResetTarget
+from universal_silabs_flasher.const import (
+    DEFAULT_PROBE_METHODS,
+    ApplicationType,
+    ResetTarget,
+)
 from universal_silabs_flasher.flash import main
 
 
@@ -77,7 +81,7 @@ def mock_connections():
 
 
 @pytest.mark.parametrize(
-    "args,expected_device,expected_baudrate_overrides,expected_probe_methods,expected_reset",
+    "args,expected_device,expected_probe_methods,expected_reset",
     [
         # Basic flash command (uses defaults)
         (
@@ -89,14 +93,7 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {},
-            [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
-            ],
+            DEFAULT_PROBE_METHODS,
             [],
         ),
         # With verbose flags (uses defaults)
@@ -110,17 +107,10 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB1",
-            {},
-            [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
-            ],
+            DEFAULT_PROBE_METHODS,
             [],
         ),
-        # With custom bootloader baudrate
+        # With custom bootloader baudrate (deprecated flag)
         (
             [
                 "--device",
@@ -132,17 +122,19 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {ApplicationType.GECKO_BOOTLOADER: [115200]},
             [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
+                (ApplicationType.GECKO_BOOTLOADER, 115200),
+                (ApplicationType.CPC, 460800),
+                (ApplicationType.CPC, 115200),
+                (ApplicationType.CPC, 230400),
+                (ApplicationType.EZSP, 115200),
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.ROUTER, 115200),
+                (ApplicationType.SPINEL, 460800),
             ],
             [],
         ),
-        # With multiple custom baudrates
+        # With multiple custom baudrates (deprecated flags)
         (
             [
                 "--device",
@@ -156,20 +148,19 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {
-                ApplicationType.GECKO_BOOTLOADER: [115200, 230400],
-                ApplicationType.EZSP: [115200],
-            },
             [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
+                (ApplicationType.GECKO_BOOTLOADER, 115200),
+                (ApplicationType.GECKO_BOOTLOADER, 230400),
+                (ApplicationType.CPC, 460800),
+                (ApplicationType.CPC, 115200),
+                (ApplicationType.CPC, 230400),
+                (ApplicationType.EZSP, 115200),
+                (ApplicationType.ROUTER, 115200),
+                (ApplicationType.SPINEL, 460800),
             ],
             [],
         ),
-        # With custom probe methods
+        # With custom probe methods (deprecated flag)
         (
             [
                 "--device",
@@ -183,8 +174,13 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {},
-            [ApplicationType.EZSP, ApplicationType.CPC],
+            [
+                (ApplicationType.EZSP, 115200),
+                (ApplicationType.EZSP, 460800),
+                (ApplicationType.CPC, 460800),
+                (ApplicationType.CPC, 115200),
+                (ApplicationType.CPC, 230400),
+            ],
             [],
         ),
         # With single bootloader reset method
@@ -199,14 +195,7 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {},
-            [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
-            ],
+            DEFAULT_PROBE_METHODS,
             [ResetTarget.RTS_DTR],
         ),
         # With multiple bootloader reset methods (chained)
@@ -221,14 +210,7 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "/dev/ttyUSB0",
-            {},
-            [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
-            ],
+            DEFAULT_PROBE_METHODS,
             [ResetTarget.RTS_DTR, ResetTarget.BAUDRATE],
         ),
         # With socket device
@@ -241,14 +223,7 @@ def mock_connections():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "socket://192.168.1.100:1234",
-            {},
-            [
-                ApplicationType.GECKO_BOOTLOADER,
-                ApplicationType.CPC,
-                ApplicationType.EZSP,
-                ApplicationType.SPINEL,
-                ApplicationType.ROUTER,
-            ],
+            DEFAULT_PROBE_METHODS,
             [],
         ),
     ],
@@ -257,7 +232,6 @@ def test_flash_command_argument_parsing(
     mock_connections,
     args,
     expected_device,
-    expected_baudrate_overrides,
     expected_probe_methods,
     expected_reset,
 ):
@@ -270,11 +244,6 @@ def test_flash_command_argument_parsing(
 
     flasher = result.ctx.obj["flasher"]
     assert flasher._device == expected_device
-
-    # Check baudrate overrides
-    for app_type, baudrates in expected_baudrate_overrides.items():
-        assert flasher._baudrates[app_type] == baudrates
-
     assert set(flasher._probe_methods) == set(expected_probe_methods)
     assert flasher._reset_targets == expected_reset
 
@@ -418,7 +387,7 @@ def test_dump_gbl_metadata_command():
             ["--device", "/dev/ttyUSB0", "write-ieee"],
             "Missing option",
         ),
-        # Deprecated --baudrate flag
+        # Removed --baudrate flag
         (
             [
                 "--device",
@@ -429,7 +398,7 @@ def test_dump_gbl_metadata_command():
                 "--firmware",
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
-            "deprecated",
+            "no such option",
         ),
     ],
 )

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -97,49 +97,13 @@ async def test_trigger_bootloader_reset_first_probe_succeeds():
     assert result.version == Version("1.0.0")
     assert result.baudrate == 115200
 
-    # Only first reset target should be attempted
-    assert mock_trigger.mock_calls == [call(ResetTarget.RTS_DTR)]
-    # Only one probe attempt for the first reset target
-    assert mock_probe.mock_calls == [call(run_firmware=False, baudrate=115200)]
-
-
-async def test_trigger_bootloader_reset_second_probe_succeeds():
-    flasher = Flasher(
-        device="/dev/ttyMOCK",
-        bootloader_reset=(ResetTarget.RTS_DTR, ResetTarget.BAUDRATE),
-    )
-
-    with (
-        patch.object(flasher, "trigger_bootloader") as mock_trigger,
-        patch.object(
-            flasher,
-            "probe_gecko_bootloader",
-            side_effect=[
-                asyncio.TimeoutError,  # First reset target fails
-                ProbeResult(  # Second reset target succeeds
-                    version=Version("1.0.0"),
-                    continue_probing=False,
-                    baudrate=115200,
-                ),
-            ],
-        ) as mock_probe,
-    ):
-        result = await flasher.trigger_bootloader_reset()
-
-    assert result is not None
-    assert result.version == Version("1.0.0")
-    assert result.baudrate == 115200
-
-    # Both reset targets should be attempted
+    # All reset targets are triggered upfront
     assert mock_trigger.mock_calls == [
         call(ResetTarget.RTS_DTR),
         call(ResetTarget.BAUDRATE),
     ]
-    # Two probe attempts - one for each reset target
-    assert mock_probe.mock_calls == [
-        call(run_firmware=False, baudrate=115200),
-        call(run_firmware=False, baudrate=115200),
-    ]
+    # Only one probe attempt since the first one succeeds
+    assert mock_probe.mock_calls == [call(run_firmware=False, baudrate=115200)]
 
 
 async def test_trigger_bootloader_reset_all_probes_fail():
@@ -160,14 +124,13 @@ async def test_trigger_bootloader_reset_all_probes_fail():
 
     assert result is None
 
-    # Both reset targets should be attempted
+    # All reset targets are triggered upfront
     assert mock_trigger.mock_calls == [
         call(ResetTarget.RTS_DTR),
         call(ResetTarget.BAUDRATE),
     ]
-    # Two probe attempts - one for each reset target
+    # One probe attempt at the only bootloader baudrate
     assert mock_probe.mock_calls == [
-        call(run_firmware=False, baudrate=115200),
         call(run_firmware=False, baudrate=115200),
     ]
 

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -42,13 +42,25 @@ FW_IMAGE_TYPE_TO_APPLICATION_TYPE = {
 }
 
 
-DEFAULT_BAUDRATES = {
-    ApplicationType.GECKO_BOOTLOADER: [115200],
-    ApplicationType.EZSP: [115200, 460800],
-    ApplicationType.SPINEL: [460800],
-    ApplicationType.ROUTER: [115200],
-    ApplicationType.CPC: [460800, 115200, 230400],
-}
+DEFAULT_PROBE_METHODS = (
+    (ApplicationType.GECKO_BOOTLOADER, 115200),
+    (ApplicationType.EZSP, 115200),
+    (ApplicationType.EZSP, 460800),
+    (ApplicationType.SPINEL, 460800),
+    (ApplicationType.CPC, 460800),
+    (ApplicationType.CPC, 115200),
+    (ApplicationType.CPC, 230400),
+    (ApplicationType.ROUTER, 115200),
+)
+
+# Backwards compat
+DEFAULT_BAUDRATES: dict[ApplicationType, list[int]] = {}
+
+for method, baudrate in DEFAULT_PROBE_METHODS:
+    if method not in DEFAULT_BAUDRATES:
+        DEFAULT_BAUDRATES[method] = []
+
+    DEFAULT_BAUDRATES[method].append(baudrate)
 
 
 class ResetTarget(enum.Enum):

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -199,14 +199,13 @@ class SerialPort(click.ParamType):
     show_default=True,
     type=ClickProbeMethods(),
     default=",".join(
-        f"{method.name.lower()}:{baudrate}"
-        for method, baudrate in DEFAULT_PROBE_METHODS
+        f"{method.value}:{baudrate}" for method, baudrate in DEFAULT_PROBE_METHODS
     ),
     help=(
         "Comma-separated list of application type and baudrate pairs to use when"
         " probing the device. Each pair should be in the format"
         " '<application_type>:<baudrate>'. Valid application types: "
-        f"{', '.join([m.name.lower() for m in ApplicationType])}. Example: "
+        f"{', '.join([m.value for m in ApplicationType])}. Example: "
         "'ezsp:115200,ezsp:460800,spinel:460800'"
     ),
 )

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -227,18 +227,25 @@ def main(
         param = next(p for p in ctx.command.params if p.name == "device")
         raise click.MissingParameter(ctx=ctx, param=param)
 
+    baudrates = {
+        ApplicationType.GECKO_BOOTLOADER: bootloader_baudrate,
+        ApplicationType.CPC: cpc_baudrate,
+        ApplicationType.EZSP: ezsp_baudrate,
+        ApplicationType.ROUTER: router_baudrate,
+        ApplicationType.SPINEL: spinel_baudrate,
+    }
+
+    probe_methods = []
+
+    for method in probe_method:
+        for baudrate in baudrates[method]:
+            probe_methods.append((method, baudrate))
+
     ctx.obj = {
         "verbosity": verbose,
         "flasher": Flasher(
             device=device,
-            baudrates={
-                ApplicationType.GECKO_BOOTLOADER: bootloader_baudrate,
-                ApplicationType.CPC: cpc_baudrate,
-                ApplicationType.EZSP: ezsp_baudrate,
-                ApplicationType.ROUTER: router_baudrate,
-                ApplicationType.SPINEL: spinel_baudrate,
-            },
-            probe_methods=probe_method,
+            probe_methods=probe_methods,
             bootloader_reset=tuple(bootloader_reset),
         ),
     }
@@ -348,26 +355,13 @@ async def flash(
     if metadata is not None and metadata.fw_type is not None:
         app_type = FW_IMAGE_TYPE_TO_APPLICATION_TYPE[metadata.fw_type]
 
-        # Probe with the firmware's app type first
-        if (
-            ctx.parent.get_parameter_source("probe_method")
-            == click.core.ParameterSource.DEFAULT
-        ):
-            _LOGGER.debug("Probing app type %s first", app_type)
-            flasher._probe_methods = put_first(
-                flasher._probe_methods, [ApplicationType.GECKO_BOOTLOADER, app_type]
-            )
+        _LOGGER.debug(
+            "Probing app type %s at %s baud first", app_type, metadata.baudrate
+        )
+        flasher._probe_methods = put_first(
+            flasher._probe_methods, [(app_type, metadata.baudrate)]
+        )
 
-        # Probe with the firmware's baudrate first
-        if (
-            metadata.baudrate is not None
-            and ctx.parent.get_parameter_source(f"{app_type.value}_baudrate")
-            == click.core.ParameterSource.DEFAULT
-        ):
-            _LOGGER.debug("Probing with %s baudrate first", metadata.baudrate)
-            flasher._baudrates[app_type] = put_first(
-                flasher._baudrates[app_type], [metadata.baudrate]
-            )
     # Maintain backward compatibility with the deprecated reset flags
     reset_msg = (
         "The '%s' flag is deprecated. Use '--bootloader-reset' "

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -19,6 +19,7 @@ import zigpy.types
 from .common import CommaSeparatedNumbers, put_first
 from .const import (
     DEFAULT_BAUDRATES,
+    DEFAULT_PROBE_METHODS,
     FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
     ApplicationType,
     ResetTarget,
@@ -95,6 +96,63 @@ class EnumWithSeparator(click.ParamType):
         return enums
 
 
+class ClickProbeMethods(click.ParamType):
+    """Click validator that accepts probe methods in the format
+    '<application_type>:<baudrate>,<application_type>:<baudrate>,...'
+    """
+
+    name = "probe_methods"
+
+    def convert(
+        self,
+        value: str | list[tuple[ApplicationType, int]],
+        param: click.Parameter,
+        ctx: click.Context,
+    ) -> list[tuple[ApplicationType, int]]:
+        if isinstance(value, list):
+            return value
+
+        methods = value.split(",")
+        result = []
+
+        for method in methods:
+            parts = method.split(":")
+
+            if len(parts) != 2:
+                self.fail(
+                    f"invalid probe method {method!r}, must be in the format"
+                    f" '<application_type>:<baudrate>'",
+                    param,
+                    ctx,
+                )
+
+            app_type_str, baudrate_str = parts
+
+            try:
+                app_type = ApplicationType(app_type_str)
+            except ValueError:
+                expected = [m.value for m in ApplicationType]
+                self.fail(
+                    f"invalid application type {app_type_str!r}, must be one of: "
+                    f"{', '.join(expected)}",
+                    param,
+                    ctx,
+                )
+
+            try:
+                baudrate = int(baudrate_str)
+            except ValueError:
+                self.fail(
+                    f"invalid baudrate {baudrate_str!r}, must be an integer",
+                    param,
+                    ctx,
+                )
+
+            result.append((app_type, baudrate))
+
+        return result
+
+
 class SerialPort(click.ParamType):
     """Click validator that accepts serial ports."""
 
@@ -136,43 +194,21 @@ class SerialPort(click.ParamType):
 @click.group()
 @click.option("-v", "--verbose", count=True)
 @click.option("--device", type=SerialPort())
-@click.option("--baudrate", hidden=True)
 @click.option(
-    "--bootloader-baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
-    type=CommaSeparatedNumbers(),
+    "--probe-methods",
     show_default=True,
-)
-@click.option(
-    "--cpc-baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.CPC],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-)
-@click.option(
-    "--ezsp-baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.EZSP],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-)
-@click.option(
-    "--router-baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.ROUTER],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-)
-@click.option(
-    "--spinel-baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.SPINEL],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-)
-@click.option(
-    "--probe-method",
-    multiple=True,
-    default=[m.value for m in ApplicationType],
-    callback=click_enum_validator_factory(ApplicationType),
-    show_default=True,
+    type=ClickProbeMethods(),
+    default=",".join(
+        f"{method.name.lower()}:{baudrate}"
+        for method, baudrate in DEFAULT_PROBE_METHODS
+    ),
+    help=(
+        "Comma-separated list of application type and baudrate pairs to use when"
+        " probing the device. Each pair should be in the format"
+        " '<application_type>:<baudrate>'. Valid application types: "
+        f"{', '.join([m.name.lower() for m in ApplicationType])}. Example: "
+        "'ezsp:115200,ezsp:460800,spinel:460800'"
+    ),
 )
 @click.option(
     "--bootloader-reset",
@@ -184,19 +220,76 @@ class SerialPort(click.ParamType):
         f" {', '.join([m.value for m in ResetTarget])}"
     ),
 )
+# Begin deprecated flags
+@click.option(
+    "--bootloader-baudrate",
+    "deprecated_bootloader_baudrate",
+    default=DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
+    type=CommaSeparatedNumbers(),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+@click.option(
+    "--cpc-baudrate",
+    "deprecated_cpc_baudrate",
+    default=DEFAULT_BAUDRATES[ApplicationType.CPC],
+    type=CommaSeparatedNumbers(),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+@click.option(
+    "--ezsp-baudrate",
+    "deprecated_ezsp_baudrate",
+    default=DEFAULT_BAUDRATES[ApplicationType.EZSP],
+    type=CommaSeparatedNumbers(),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+@click.option(
+    "--router-baudrate",
+    "deprecated_router_baudrate",
+    default=DEFAULT_BAUDRATES[ApplicationType.ROUTER],
+    type=CommaSeparatedNumbers(),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+@click.option(
+    "--spinel-baudrate",
+    "deprecated_spinel_baudrate",
+    default=DEFAULT_BAUDRATES[ApplicationType.SPINEL],
+    type=CommaSeparatedNumbers(),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+@click.option(
+    "--probe-method",
+    "deprecated_probe_methods",
+    multiple=True,
+    default=[m.value for m in ApplicationType],
+    callback=click_enum_validator_factory(ApplicationType),
+    show_default=True,
+    hidden=True,
+    deprecated=True,
+)
+# End deprecated flags
 @click.pass_context
 def main(
     ctx: click.Context,
     verbose: bool,
     device: str,
-    baudrate: int | None,
-    bootloader_baudrate: list[int],
-    cpc_baudrate: list[int],
-    ezsp_baudrate: list[int],
-    router_baudrate: list[int],
-    spinel_baudrate: list[int],
-    probe_method: list[ApplicationType],
+    probe_methods: list[tuple[ApplicationType, int]],
     bootloader_reset: list[ResetTarget],
+    deprecated_bootloader_baudrate: list[int],
+    deprecated_cpc_baudrate: list[int],
+    deprecated_ezsp_baudrate: list[int],
+    deprecated_router_baudrate: list[int],
+    deprecated_spinel_baudrate: list[int],
+    deprecated_probe_methods: list[ApplicationType],
 ) -> None:
     coloredlogs.install(
         fmt=(
@@ -207,14 +300,6 @@ def main(
         ),
         level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, verbose)],
     )
-
-    # Override all application baudrates if a specific value is provided
-    if ctx.get_parameter_source("baudrate") != click.core.ParameterSource.DEFAULT:
-        raise click.ClickException(
-            "The `--baudrate` flag is deprecated. Remove it to rely on auto baudrate"
-            " probing, or replace it with an application-specific baudrate flag"
-            " (see `--help`)"
-        )
 
     # To maintain some backwards compatibility, make `--device` required only when we
     # are actually invoking a command that interacts with a device
@@ -227,19 +312,39 @@ def main(
         param = next(p for p in ctx.command.params if p.name == "device")
         raise click.MissingParameter(ctx=ctx, param=param)
 
-    baudrates = {
-        ApplicationType.GECKO_BOOTLOADER: bootloader_baudrate,
-        ApplicationType.CPC: cpc_baudrate,
-        ApplicationType.EZSP: ezsp_baudrate,
-        ApplicationType.ROUTER: router_baudrate,
-        ApplicationType.SPINEL: spinel_baudrate,
-    }
+    # Finally, deprecated baudrate baudrate flags should be converted
+    if any(
+        ctx.get_parameter_source(param) != click.core.ParameterSource.DEFAULT
+        for param in (
+            "deprecated_bootloader_baudrate",
+            "deprecated_cpc_baudrate",
+            "deprecated_ezsp_baudrate",
+            "deprecated_router_baudrate",
+            "deprecated_spinel_baudrate",
+            "deprecated_probe_methods",
+        )
+    ):
+        if (
+            ctx.get_parameter_source("probe_methods")
+            != click.core.ParameterSource.DEFAULT
+        ):
+            raise click.ClickException(
+                "`--probe-methods` cannot be used with deprecated baudrate flags"
+            )
 
-    probe_methods = []
+        baudrates = {
+            ApplicationType.GECKO_BOOTLOADER: deprecated_bootloader_baudrate,
+            ApplicationType.CPC: deprecated_cpc_baudrate,
+            ApplicationType.EZSP: deprecated_ezsp_baudrate,
+            ApplicationType.ROUTER: deprecated_router_baudrate,
+            ApplicationType.SPINEL: deprecated_spinel_baudrate,
+        }
 
-    for method in probe_method:
-        for baudrate in baudrates[method]:
-            probe_methods.append((method, baudrate))
+        probe_methods = []
+
+        for method in deprecated_probe_methods:
+            for baudrate in baudrates[method]:
+                probe_methods.append((method, baudrate))
 
     ctx.obj = {
         "verbosity": verbose,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -311,18 +311,19 @@ class Flasher:
             self.app_baudrate = result.baudrate
             break
 
-        if bootloader_probe and self._reset_targets:
-            # We have no valid application image but can still re-enter the
-            # bootloader whenever we want
-            await self.trigger_bootloader_reset(run_firmware=False)
+        if self.app_type is None:
+            if bootloader_probe and self._reset_targets:
+                # We have no valid application image but can still re-enter the
+                # bootloader whenever we want
+                await self.trigger_bootloader_reset(run_firmware=False)
 
-            self.app_type = ApplicationType.GECKO_BOOTLOADER
-            self.app_version = bootloader_probe.version
-            self.app_baudrate = bootloader_probe.baudrate
-            self.bootloader_baudrate = bootloader_probe.baudrate
-            _LOGGER.warning("Bootloader did not launch a valid application")
-        else:
-            raise RuntimeError("Failed to probe running application type")
+                self.app_type = ApplicationType.GECKO_BOOTLOADER
+                self.app_version = bootloader_probe.version
+                self.app_baudrate = bootloader_probe.baudrate
+                self.bootloader_baudrate = bootloader_probe.baudrate
+                _LOGGER.warning("Bootloader did not launch a valid application")
+            else:
+                raise RuntimeError("Failed to probe running application type")
 
         _LOGGER.info(
             "Detected %s, version %s at %s baudrate (bootloader baudrate %s)",

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -308,27 +308,25 @@ class Flasher:
                 bootloader_probe = result
                 self.bootloader_baudrate = bootloader_probe.baudrate
 
-            if result.continue_probing:
-                continue
-
-            self.app_type = probe_method
-            self.app_version = result.version
-            self.app_baudrate = result.baudrate
-            break
+            if not result.continue_probing:
+                self.app_type = probe_method
+                self.app_version = result.version
+                self.app_baudrate = result.baudrate
+                break
 
         if self.app_type is None:
-            if bootloader_probe and self._reset_targets:
-                # We have no valid application image but can still re-enter the
-                # bootloader whenever we want
-                await self.trigger_bootloader_reset(run_firmware=False)
-
-                self.app_type = ApplicationType.GECKO_BOOTLOADER
-                self.app_version = bootloader_probe.version
-                self.app_baudrate = bootloader_probe.baudrate
-                self.bootloader_baudrate = bootloader_probe.baudrate
-                _LOGGER.warning("Bootloader did not launch a valid application")
-            else:
+            if not bootloader_probe or not self._reset_targets:
                 raise RuntimeError("Failed to probe running application type")
+
+            # We have no valid application image but can still re-enter the
+            # bootloader whenever we want
+            await self.trigger_bootloader_reset(run_firmware=False)
+
+            self.app_type = ApplicationType.GECKO_BOOTLOADER
+            self.app_version = bootloader_probe.version
+            self.app_baudrate = bootloader_probe.baudrate
+            self.bootloader_baudrate = bootloader_probe.baudrate
+            _LOGGER.debug("Bootloader did not launch a valid application")
 
         _LOGGER.info(
             "Detected %s, version %s at %s baudrate (bootloader baudrate %s)",

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -298,6 +298,7 @@ class Flasher:
             try:
                 result = await probe_funcs[probe_method](baudrate=baudrate)
             except asyncio.TimeoutError:
+                _LOGGER.debug("Probe timed out")
                 continue
 
             _LOGGER.debug("Probe result: %s", result)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -274,6 +274,11 @@ class Flasher:
         if bootloader_probe is not None:
             self.bootloader_baudrate = bootloader_probe.baudrate
 
+            if not bootloader_probe.continue_probing:
+                # If the bootloader can be entered but fails to launch an application
+                # there is no point probing further, it'll just waste time
+                probe_methods = []
+
         for probe_method, baudrate in probe_methods:
             # Don't probe the bootloader twice
             if (
@@ -305,19 +310,19 @@ class Flasher:
             self.app_version = result.version
             self.app_baudrate = result.baudrate
             break
-        else:
-            if bootloader_probe and self._reset_targets:
-                # We have no valid application image but can still re-enter the
-                # bootloader whenever we want
-                await self.trigger_bootloader_reset(run_firmware=False)
 
-                self.app_type = ApplicationType.GECKO_BOOTLOADER
-                self.app_version = bootloader_probe.version
-                self.app_baudrate = bootloader_probe.baudrate
-                self.bootloader_baudrate = bootloader_probe.baudrate
-                _LOGGER.warning("Bootloader did not launch a valid application")
-            else:
-                raise RuntimeError("Failed to probe running application type")
+        if bootloader_probe and self._reset_targets:
+            # We have no valid application image but can still re-enter the
+            # bootloader whenever we want
+            await self.trigger_bootloader_reset(run_firmware=False)
+
+            self.app_type = ApplicationType.GECKO_BOOTLOADER
+            self.app_version = bootloader_probe.version
+            self.app_baudrate = bootloader_probe.baudrate
+            self.bootloader_baudrate = bootloader_probe.baudrate
+            _LOGGER.warning("Bootloader did not launch a valid application")
+        else:
+            raise RuntimeError("Failed to probe running application type")
 
         _LOGGER.info(
             "Detected %s, version %s at %s baudrate (bootloader baudrate %s)",

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -59,14 +59,19 @@ class Flasher:
         ] = DEFAULT_PROBE_METHODS,
         device: str,
         bootloader_reset: str | tuple[ResetTarget, ...] = (),
+        # To restore flasher "state", we can pass these to the constructor
+        app_type: ApplicationType | None = None,
+        app_version: Version | None = None,
+        app_baudrate: int | None = None,
+        bootloader_baudrate: int | None = None,
     ):
         self._probe_methods = probe_methods
         self._device = device
 
-        self.app_type: ApplicationType | None = None
-        self.app_version: Version | None = None
-        self.app_baudrate: int | None = None
-        self.bootloader_baudrate: int | None = None
+        self.app_type = app_type
+        self.app_version = app_version
+        self.app_baudrate = app_baudrate
+        self.bootloader_baudrate = bootloader_baudrate
 
         if isinstance(bootloader_reset, str):
             bootloader_reset = (ResetTarget(bootloader_reset),)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -333,6 +333,13 @@ class Flasher:
         )
 
     async def enter_bootloader(self) -> None:
+        # If we can enter the bootloader externally, do it
+        bootloader_probe = await self.trigger_bootloader_reset()
+        if bootloader_probe is not None:
+            self.bootloader_baudrate = bootloader_probe.baudrate
+            return
+
+        # Otherwise, probe the application type and enter the bootloader from there
         if self.app_type is None:
             await self.probe_app_type()
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -19,7 +19,7 @@ from .common import (
     pad_to_multiple,
 )
 from .const import (
-    DEFAULT_BAUDRATES,
+    DEFAULT_PROBE_METHODS,
     RESET_CONFIGS,
     ApplicationType,
     BaudrateResetConfig,
@@ -54,18 +54,12 @@ class Flasher:
     def __init__(
         self,
         *,
-        baudrates: dict[ApplicationType, list[int]] = DEFAULT_BAUDRATES,
-        probe_methods: tuple[ApplicationType, ...] = (
-            ApplicationType.GECKO_BOOTLOADER,
-            ApplicationType.EZSP,
-            ApplicationType.SPINEL,
-            ApplicationType.CPC,
-            ApplicationType.ROUTER,
-        ),
+        probe_methods: typing.Sequence[
+            tuple[ApplicationType, int]
+        ] = DEFAULT_PROBE_METHODS,
         device: str,
         bootloader_reset: str | tuple[ResetTarget, ...] = (),
     ):
-        self._baudrates = baudrates
         self._probe_methods = probe_methods
         self._device = device
 
@@ -110,12 +104,9 @@ class Flasher:
                 chip = await find_gpiochip_by_label(config.chip_type)
 
             if config.chip_type == "uart":
-                # The baudrate isn't really necessary, since we're just using flow
-                # control pins
-                baudrate = self._baudrates[ApplicationType.GECKO_BOOTLOADER][0]
-
+                # The baudrate isn't necessary, since we're just using flow control pins
                 async with connect_protocol(
-                    self._device, baudrate, FlowControlSerialProtocol
+                    self._device, 115200, FlowControlSerialProtocol
                 ) as uart:
                     for pattern in config.pattern:
                         await uart.set_signals(**pattern.pins)
@@ -209,44 +200,61 @@ class Flasher:
     ) -> ProbeResult | None:
         """Reset into the bootloader by trying the probing methods, one by one."""
 
+        # If we have no way to enter the bootloader, don't try
+        if not self._reset_targets:
+            return None
+
+        # We don't really care which method works, just try them all at once
         for target in self._reset_targets:
             _LOGGER.info(f"Triggering {target.value} bootloader")
             await self.trigger_bootloader(target)
 
-            for baudrate in self._baudrates[ApplicationType.GECKO_BOOTLOADER]:
-                try:
-                    probe_result = await self.probe_gecko_bootloader(
-                        run_firmware=run_firmware, baudrate=baudrate
-                    )
-                except asyncio.TimeoutError:
-                    continue
-                else:
-                    _LOGGER.info(
-                        f"Successfully entered bootloader using {target.value} reset"
-                    )
-                    return probe_result
+        # Try probing the bootloader at all known baudrates
+        bootloader_baudrates = [
+            baudrate
+            for method, baudrate in self._probe_methods
+            if method == ApplicationType.GECKO_BOOTLOADER
+        ] or [
+            baudrate
+            for method, baudrate in DEFAULT_PROBE_METHODS
+            if method == ApplicationType.GECKO_BOOTLOADER
+        ]
 
+        for baudrate in bootloader_baudrates:
+            try:
+                probe_result = await self.probe_gecko_bootloader(
+                    run_firmware=run_firmware, baudrate=baudrate
+                )
+            except asyncio.TimeoutError:
+                continue
+            else:
+                _LOGGER.debug("Successfully triggered bootloader")
+                return probe_result
+
+        _LOGGER.debug("Failed to trigger bootloader")
         return None
 
     async def probe_app_type(
         self,
-        types: typing.Iterable[ApplicationType] | None = None,
-        try_first: tuple[ApplicationType, ...] = (),
+        only: typing.Sequence[ApplicationType] | None = None,
     ) -> None:
-        if types is None:
-            types = self._probe_methods
-
-        # fmt: off
-        types = (
-              [m for m in types if m in try_first]
-            + [m for m in types if m not in try_first]
-        )
-        # fmt: on
+        if only is None:
+            probe_methods = self._probe_methods
+        else:
+            probe_methods = [
+                (method, baudrate)
+                for method, baudrate in self._probe_methods
+                if method in only
+            ]
 
         # Only run firmware from the bootloader if we have bootloader reset and
         # other probe methods
-        only_probe_bootloader = types == [ApplicationType.GECKO_BOOTLOADER]
+        only_probe_bootloader = all(
+            m == ApplicationType.GECKO_BOOTLOADER for m, _ in probe_methods
+        )
+
         run_firmware = self._reset_targets and not only_probe_bootloader
+
         probe_funcs = {
             ApplicationType.GECKO_BOOTLOADER: (
                 lambda baudrate: self.probe_gecko_bootloader(
@@ -266,9 +274,7 @@ class Flasher:
         if bootloader_probe is not None:
             self.bootloader_baudrate = bootloader_probe.baudrate
 
-        for probe_method, baudrate in (
-            (m, b) for m in types for b in self._baudrates[m]
-        ):
+        for probe_method, baudrate in probe_methods:
             # Don't probe the bootloader twice
             if (
                 probe_method == ApplicationType.GECKO_BOOTLOADER
@@ -359,9 +365,9 @@ class Flasher:
         else:
             raise RuntimeError(f"Invalid application type: {self.app_type}")
 
-        # Probe the bootloader baudrate
+        # Probe the bootloader baudrate if not already known
         if self.bootloader_baudrate is None:
-            await self.probe_app_type(types=[ApplicationType.GECKO_BOOTLOADER])
+            await self.probe_app_type(only=[ApplicationType.GECKO_BOOTLOADER])
 
     async def flash_firmware(
         self,
@@ -395,9 +401,7 @@ class Flasher:
     async def write_emberznet_eui64(
         self, new_ieee: zigpy.types.EUI64, force: bool = False
     ) -> bool:
-        await self.probe_app_type(
-            try_first=[ApplicationType.GECKO_BOOTLOADER, ApplicationType.EZSP]
-        )
+        await self.probe_app_type()
 
         if self.app_type != ApplicationType.EZSP:
             raise RuntimeError(f"Device is not running EmberZNet: {self.app_type}")


### PR DESCRIPTION
To allow reordering with more granularity than app type, we should migrate to just specifying the exact pairs explicitly in sequence.