### PR TITLE
Have the `reset()` command use `tid=0`

### DIFF
--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -217,10 +217,12 @@ class SpinelProtocol(SerialProtocol):
         retries: int = 2,
         timeout: float = COMMAND_TIMEOUT,
         retry_delay: float = 0.1,
+        tid: int | None = None,
     ) -> SpinelFrame | None:
         # A transaction ID of `0` is special: we only use 1-15
-        self._transaction_id = (self._transaction_id + 1) % (0b1111 - 1)
-        tid = 1 + self._transaction_id
+        if tid is None:
+            self._transaction_id = (self._transaction_id + 1) % (0b1111 - 1)
+            tid = 1 + self._transaction_id
 
         future = asyncio.get_running_loop().create_future()
         self._pending_frames[tid] = future
@@ -332,6 +334,7 @@ class SpinelProtocol(SerialProtocol):
             CommandID.RESET,
             reset_type.serialize(),
             wait_response=False,
+            tid=0,  # Reset uses TID=0
         )
 
         if reset_type == ResetReason.BOOTLOADER:


### PR DESCRIPTION
From a OTBR user log, I noticed something interesting in the following comment (https://github.com/home-assistant/addons/issues/4210#issuecomment-3518712058):

```python
[21:52:49] INFO: Starting otbr-agent...
[NOTE]-AGENT---: Running 0.3.0-b067e5ac-dirty
[NOTE]-AGENT---: Thread version: 1.3.0
[NOTE]-AGENT---: Thread interface: wpan0
[NOTE]-AGENT---: Radio URL: spinel+hdlc+uart:///dev/serial/by-id/usb-SMLIGHT_SMLIGHT_SLZB-07p7_36(...)91-if00-port0?uart-baudrate=460800&uart-init-deassert
[NOTE]-AGENT---: Radio URL: trel://enp0s18
[NOTE]-ILS-----: Infra link selected: enp0s18
[INFO]-RCP_HOS-: OpenThread log level changed to 5
56d.16:47:54.073 [D] P-SpinelDrive-: Sent spinel frame, flg:0x2, iid:0, tid:0, cmd:RESET
56d.16:47:54.073 [D] P-SpinelDrive-: Waiting response: key=0
56d.16:47:54.089 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:0, cmd:PROP_VALUE_IS, key:LAST_STATUS, status:RESET_EXTERNAL
56d.16:47:54.089 [I] P-SpinelDrive-: co-processor reset: RESET_EXTERNAL
56d.16:47:54.089 [C] P-SpinelDrive-: Software reset co-processor successfully
56d.16:47:54.089 [D] P-SpinelDrive-: Sent spinel frame, flg:0x2, iid:0, tid:1, cmd:PROP_VALUE_GET, key:PROTOCOL_VERSION
56d.16:47:54.089 [D] P-SpinelDrive-: Waiting response: key=1
56d.16:47:54.092 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:1, cmd:PROP_VALUE_IS, key:PROTOCOL_VERSION, major:4, minor:3
56d.16:47:54.092 [D] P-SpinelDrive-: Sent spinel frame, flg:0x2, iid:0, tid:1, cmd:PROP_VALUE_GET, key:NCP_VERSION
56d.16:47:54.092 [D] P-SpinelDrive-: Waiting response: key=2
56d.16:47:54.097 [D] P-SpinelDrive-: Received spinel frame, flg:0x2, iid:0, tid:1, cmd:PROP_VALUE_IS, key:NCP_VERSION, version:OPENTHREAD/1.3.0.1; CC13XX_CC26XX; Jun 11 2024 04:59:11
(...)
```

Specifically, `Sent spinel frame, flg:0x2, iid:0, tid:0, cmd:RESET`.