### PR TITLE
Fix bootloader trigger when hardware reset fails

### DIFF
--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -1,12 +1,20 @@
 import asyncio
+from collections.abc import Generator
 from unittest.mock import MagicMock, call, patch
 
+import pytest
 import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
 from universal_silabs_flasher.const import ApplicationType, ResetTarget
 from universal_silabs_flasher.flasher import Flasher, ProbeResult
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
+
+
+@pytest.fixture(autouse=True)
+def reduce_timeouts() -> Generator[None, None, None]:
+    with patch("universal_silabs_flasher.flasher.BOOTLOADER_LAUNCH_DELAY", 0.05):
+        yield
 
 
 async def test_write_emberznet_eui64():
@@ -49,7 +57,7 @@ async def test_baudrate_reset_pattern():
     ) as mock_connect_protocol:
         mock_uart = mock_connect_protocol.return_value.__aenter__.return_value
         mock_uart._transport.write = MagicMock()
-        await flasher.trigger_bootloader_reset()
+        await flasher.trigger_bootloader_reset(run_firmware=False)
 
     assert mock_connect_protocol.mock_calls == [
         # Connect with 150 baud
@@ -91,7 +99,7 @@ async def test_trigger_bootloader_reset_first_probe_succeeds():
             ),
         ) as mock_probe,
     ):
-        result = await flasher.trigger_bootloader_reset()
+        result = await flasher.trigger_bootloader_reset(run_firmware=False)
 
     assert result is not None
     assert result.version == Version("1.0.0")
@@ -120,7 +128,7 @@ async def test_trigger_bootloader_reset_all_probes_fail():
             side_effect=asyncio.TimeoutError,  # All probes fail
         ) as mock_probe,
     ):
-        result = await flasher.trigger_bootloader_reset()
+        result = await flasher.trigger_bootloader_reset(run_firmware=False)
 
     assert result is None
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -43,6 +43,10 @@ _LOGGER = logging.getLogger(__name__)
 BOOTLOADER_LAUNCH_DELAY = 3
 
 
+class FailedToEnterBootloaderError(Exception):
+    """Failed to enter the bootloader."""
+
+
 @dataclasses.dataclass(frozen=True)
 class ProbeResult:
     version: Version | None
@@ -201,7 +205,7 @@ class Flasher:
         )
 
     async def trigger_bootloader_reset(
-        self, *, run_firmware: bool = False
+        self, *, run_firmware: bool
     ) -> ProbeResult | None:
         """Reset into the bootloader by trying the probing methods, one by one."""
 
@@ -216,6 +220,11 @@ class Flasher:
 
         await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
 
+        return await self._detect_gecko_bootloader(run_firmware=run_firmware)
+
+    async def _detect_gecko_bootloader(
+        self, *, run_firmware: bool
+    ) -> ProbeResult | None:
         # Try probing the bootloader at all known baudrates
         bootloader_baudrates = [
             baudrate
@@ -235,10 +244,8 @@ class Flasher:
             except asyncio.TimeoutError:
                 continue
             else:
-                _LOGGER.debug("Successfully triggered bootloader")
                 return probe_result
 
-        _LOGGER.debug("Failed to trigger bootloader")
         return None
 
     async def probe_app_type(
@@ -341,7 +348,7 @@ class Flasher:
 
     async def enter_bootloader(self) -> None:
         # If we can enter the bootloader externally, do it
-        bootloader_probe = await self.trigger_bootloader_reset()
+        bootloader_probe = await self.trigger_bootloader_reset(run_firmware=False)
         if bootloader_probe is not None:
             self.bootloader_baudrate = bootloader_probe.baudrate
             return
@@ -382,11 +389,15 @@ class Flasher:
         else:
             raise RuntimeError(f"Invalid application type: {self.app_type}")
 
-        await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
+        if self.app_type is not ApplicationType.GECKO_BOOTLOADER:
+            await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
 
-        # Probe the bootloader baudrate if not already known
-        if self.bootloader_baudrate is None:
-            await self.probe_app_type(only=[ApplicationType.GECKO_BOOTLOADER])
+        # Verify the bootloader has launched
+        bootloader_probe = await self._detect_gecko_bootloader(run_firmware=False)
+        if bootloader_probe is None:
+            raise FailedToEnterBootloaderError()
+
+        self.bootloader_baudrate = bootloader_probe.baudrate
 
     async def flash_firmware(
         self,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -410,7 +410,13 @@ class Flasher:
         # Pad the image to the XMODEM block size
         data = pad_to_multiple(data, XMODEM_BLOCK_SIZE, b"\xff")
 
-        async with self._connect_gecko_bootloader(self.bootloader_baudrate) as gecko:
+        if self.bootloader_baudrate is None:
+            _LOGGER.debug("Bootloader baudrate unknown, assuming 115200")
+            bootloader_baudrate = 115200
+        else:
+            bootloader_baudrate = self.bootloader_baudrate
+
+        async with self._connect_gecko_bootloader(bootloader_baudrate) as gecko:
             await gecko.probe()
             await gecko.upload_firmware(data, progress_callback=progress_callback)
 


### PR DESCRIPTION
https://github.com/NabuCasa/universal-silabs-flasher/pull/121 introduced a bug where we accidentally launch the application while trying to enter the bootloader, causing firmware flashing to fail. This PR fixes this scenario.

The operations are now:

1. When probing the device initially, we use the hardware trigger (if one exists) to first reset the device and ensure that we are running the actual firmware are not erroneously communicating with just the bootloader.
2. If we have no hardware reset targets and are currently in the bootloader, this is a precarious situation: we could potentially brick the device if we try to run the application. In this case, we should bail out and treat this as a device stuck in the bootloader, requiring firmware flashing.
3. If we do have hardware reset capabilities, this lets us more safely probe the potential firmware running on the device and extract an application version.

Once this is done and the upstream application decides to flash firmware, we enter the bootloader with `enter_bootloader`. If this can be done with a hardware reset method, we do so (and ensure we are actually in the bootloader after this is done). Otherwise, we rely on the application type having been probed previously to perform an application type-specific software reset back into the bootloader. The bootloader is verified to be running.