### PR TITLE
Migrate from click to argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,24 @@ $ pip install universal-silabs-flasher
 ## Usage
 
 ```console
-Usage: universal-silabs-flasher [OPTIONS] COMMAND [ARGS]...
+usage: universal-silabs-flasher [-h] [-v] [--device DEVICE] [--probe-methods PROBE_METHODS]
+                                [--bootloader-reset BOOTLOADER_RESET]
+                                {dump-gbl-metadata,probe,write-ieee,flash} ...
 
-Options:
+positional arguments:
+  {dump-gbl-metadata,probe,write-ieee,flash}
+
+options:
+  -h, --help            show this help message and exit
   -v, --verbose
-  --device PATH_OR_URL
-  --bootloader-baudrate NUMBERS   [default: 115200]
-  --cpc-baudrate NUMBERS          [default: 460800, 115200, 230400]
-  --ezsp-baudrate NUMBERS         [default: 115200, 460800]
-  --router-baudrate NUMBERS       [default: 115200]
-  --spinel-baudrate NUMBERS       [default: 460800]
-  --probe-method TEXT             [default: bootloader, cpc, ezsp, spinel,
-                                  router]
-  --bootloader-reset ENUM_WITH_SEPARATOR
-                                  Reset methods to attempt when triggering
-                                  bootloader mode. Multiple methods can be
-                                  chained by separating them with a comma.
-                                  Valid values:  yellow, ihost, slzb07,
-                                  rts_dtr, baudrate
-  --help                          Show this message and exit.
-
-Commands:
-  dump-gbl-metadata
-  flash
-  probe
-  write-ieee
+  --device DEVICE
+  --probe-methods PROBE_METHODS
+                        Comma-separated list of application type and baudrate pairs to use when probing the device.
+                        Each pair should be in the format '<application_type>:<baudrate>'. Valid application types:
+                        bootloader, cpc, ezsp, spinel, router. Example: 'ezsp:115200,ezsp:460800,spinel:460800'
+  --bootloader-reset BOOTLOADER_RESET
+                        Reset methods to attempt when triggering bootloader mode. Multiple methods can be chained by
+                        separating them with a comma. Valid values: yellow, ihost, slzb07, rts_dtr, baudrate
 ```
 
 ## Flashing firmware

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.9"
 dependencies = [
     "aiohttp",  # Explicit dependency until compatibility with async-timeout is resolved
-    "click>=8.2.0",
+    "tqdm",
     "zigpy>=0.70.0",
     "crc",
     "bellows>=0.42.0",

--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -1,47 +1,44 @@
-import click
+from argparse import ArgumentTypeError
+
 import pytest
 
 from universal_silabs_flasher.const import ResetTarget
-from universal_silabs_flasher.flash import EnumWithSeparator, SerialPort
+from universal_silabs_flasher.flash import parse_reset_methods, parse_serial_port
 
 
 def test_click_serialport_validation():
-    assert SerialPort().convert("/dev/null", None, None) == "/dev/null"
-    assert SerialPort().convert("socket://1.2.3.4", None, None) == "socket://1.2.3.4"
-    assert SerialPort().convert("COM1", None, None) == "COM1"
-    assert SerialPort().convert("\\\\.\\COM123", None, None) == "\\\\.\\COM123"
+    assert parse_serial_port("/dev/null") == "/dev/null"
+    assert parse_serial_port("socket://1.2.3.4") == "socket://1.2.3.4"
+    assert parse_serial_port("COM1") == "COM1"
+    assert parse_serial_port("\\\\.\\COM123") == "\\\\.\\COM123"
 
-    with pytest.raises(click.BadParameter) as exc_info:
-        assert SerialPort().convert("COM10", None, None)
+    with pytest.raises(ArgumentTypeError):
+        assert parse_serial_port("COM10")
 
-    with pytest.raises(click.BadParameter) as exc_info:
-        assert SerialPort().convert("http://1.2.3.4", None, None)
+    with pytest.raises(ArgumentTypeError) as exc_info:
+        assert parse_serial_port("http://1.2.3.4")
 
-    assert "invalid URL scheme" in exc_info.value.message
+    assert "invalid URL scheme" in str(exc_info.value)
 
-    with pytest.raises(click.BadParameter) as exc_info:
-        assert SerialPort().convert("/dev/serial/by-id/does-not-exist", None, None)
+    with pytest.raises(ArgumentTypeError) as exc_info:
+        assert parse_serial_port("/dev/serial/by-id/does-not-exist")
 
-    assert "does not exist" in exc_info.value.message
+    assert "does not exist" in str(exc_info.value)
 
 
 def test_enum_with_separator_single_value() -> None:
-    converter = EnumWithSeparator(ResetTarget)
-    result = converter.convert("rts_dtr", None, None)
+    result = parse_reset_methods("rts_dtr")
     assert result == [ResetTarget.RTS_DTR]
 
 
 def test_enum_with_separator_multiple_values() -> None:
-    converter = EnumWithSeparator(ResetTarget)
-    result = converter.convert("rts_dtr,baudrate", None, None)
+    result = parse_reset_methods("rts_dtr,baudrate")
     assert result == [ResetTarget.RTS_DTR, ResetTarget.BAUDRATE]
 
 
 def test_enum_with_separator_invalid_value() -> None:
-    converter = EnumWithSeparator(ResetTarget)
-
-    with pytest.raises(click.BadParameter) as exc_info:
-        converter.convert("invalid_target", None, None)
+    with pytest.raises(ArgumentTypeError) as exc_info:
+        parse_reset_methods("invalid_target")
 
     assert "'invalid_target' is invalid, must be one of:" in str(exc_info.value)
     assert "yellow" in str(exc_info.value)

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -1,5 +1,6 @@
 """CLI integration tests to ensure argument parsing works correctly."""
 
+from contextlib import ExitStack
 from dataclasses import dataclass
 import io
 from unittest.mock import AsyncMock, patch
@@ -23,7 +24,9 @@ class Result:
     flasher: Flasher
 
 
-async def invoke_main(argv: list[str], *, catch_exit: bool = True) -> Result:
+async def invoke_main(
+    argv: list[str], *, catch_exit: bool = True, mock_serial_port: bool = True
+) -> Result:
     """Invoke main() with the given argv, capturing stdout/stderr."""
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -43,37 +46,43 @@ async def invoke_main(argv: list[str], *, catch_exit: bool = True) -> Result:
         self.app_version = None
 
     try:
-        with (
-            patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init),
-            patch("sys.stdout", stdout),
-            patch("sys.stderr", stderr),
-            patch("universal_silabs_flasher.flasher.connect_protocol"),
-            patch("universal_silabs_flasher.flasher.Flasher._connect_ezsp"),
-            patch(
-                "universal_silabs_flasher.flasher.Flasher.probe_app_type",
-                mock_probe_app_type,
-            ),
-            patch(
-                "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "universal_silabs_flasher.flasher.Flasher.write_emberznet_eui64",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "universal_silabs_flasher.flasher.Flasher.flash_firmware",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "universal_silabs_flasher.flash.parse_serial_port",
-                side_effect=lambda v: v,
-            ),
-        ):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init)
+            )
+            stack.enter_context(patch("sys.stdout", stdout))
+            stack.enter_context(patch("sys.stderr", stderr))
+            stack.enter_context(
+                patch(
+                    "universal_silabs_flasher.flasher.Flasher.probe_app_type",
+                    mock_probe_app_type,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
+                    new_callable=AsyncMock,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
+                    new_callable=AsyncMock,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "universal_silabs_flasher.flasher.Flasher.flash_firmware",
+                    new_callable=AsyncMock,
+                )
+            )
+            if mock_serial_port:
+                stack.enter_context(
+                    patch(
+                        "universal_silabs_flasher.flash.parse_serial_port",
+                        side_effect=lambda v: v,
+                    )
+                )
             await main(argv)
     except SystemExit as e:
         if not catch_exit:
@@ -292,7 +301,6 @@ async def test_probe_command_argument_parsing(args, expected_device):
                 "--ieee",
                 "11:22:33:44:55:66:77:88",
                 "--force",
-                "true",
             ],
             "11:22:33:44:55:66:77:88",
             True,
@@ -445,7 +453,7 @@ async def test_invalid_argument_combinations_without_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations without mocked device validator."""
-    result = await invoke_main(args)
+    result = await invoke_main(args, mock_serial_port=False)
 
     assert result.exit_code != 0
     combined = result.output.lower() + result.stderr.lower()

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -1,10 +1,8 @@
 """CLI integration tests to ensure argument parsing works correctly."""
 
+import io
 from unittest.mock import AsyncMock, patch
 
-import click
-import click.core
-from click.testing import CliRunner
 import pytest
 
 from universal_silabs_flasher.const import (
@@ -13,32 +11,46 @@ from universal_silabs_flasher.const import (
     ResetTarget,
 )
 from universal_silabs_flasher.flash import main
+from universal_silabs_flasher.flasher import Flasher
 
 
-class CtxCliRunner(CliRunner):
-    """CliRunner that captures the Click context in the result."""
+def invoke_main(argv, *, catch_exit=True):
+    """Invoke main() with the given argv, capturing stdout/stderr."""
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    exit_code = 0
+    captured_flasher = None
 
-    def invoke(self, cli, *args, **kwargs):
-        captured = None
-        original_make_context = click.core.Command.make_context
+    original_init = Flasher.__init__
 
-        def make_context_and_capture(
-            cmd_self, info_name, cmd_args, parent=None, **extra
+    def capture_init(self, **kwargs):
+        nonlocal captured_flasher
+        original_init(self, **kwargs)
+        captured_flasher = self
+
+    try:
+        with (
+            patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
         ):
-            nonlocal captured
+            main(argv)
+    except SystemExit as e:
+        if not catch_exit:
+            raise
+        exit_code = e.code if e.code is not None else 0
 
-            ctx = original_make_context(cmd_self, info_name, cmd_args, parent, **extra)
-            if parent is None:
-                captured = ctx
-
-            return ctx
-
-        with patch.object(click.core.Command, "make_context", make_context_and_capture):
-            result = super().invoke(cli, *args, **kwargs)
-
-        result.ctx = captured
-
-        return result
+    result = type(
+        "Result",
+        (),
+        {
+            "exit_code": exit_code,
+            "output": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+            "flasher": captured_flasher,
+        },
+    )()
+    return result
 
 
 @pytest.fixture
@@ -73,8 +85,8 @@ def mock_connections():
             new_callable=AsyncMock,
         ),
         patch(
-            "universal_silabs_flasher.flash.SerialPort.convert",
-            side_effect=lambda v, *_: v,
+            "universal_silabs_flasher.flash._parse_serial_port",
+            side_effect=lambda v: v,
         ),
     ):
         yield
@@ -236,16 +248,14 @@ def test_flash_command_argument_parsing(
     expected_reset,
 ):
     """Test that flash command correctly parses various argument combinations."""
-    runner = CtxCliRunner()
-    result = runner.invoke(main, args + ["--force"], catch_exceptions=False)
+    result = invoke_main(args + ["--force"])
 
     assert result.exit_code == 0
-    assert result.ctx is not None
+    assert result.flasher is not None
 
-    flasher = result.ctx.obj["flasher"]
-    assert flasher._device == expected_device
-    assert set(flasher._probe_methods) == set(expected_probe_methods)
-    assert flasher._reset_targets == expected_reset
+    assert result.flasher._device == expected_device
+    assert set(result.flasher._probe_methods) == set(expected_probe_methods)
+    assert result.flasher._reset_targets == expected_reset
 
 
 @pytest.mark.parametrize(
@@ -258,14 +268,10 @@ def test_flash_command_argument_parsing(
 )
 def test_probe_command_argument_parsing(mock_connections, args, expected_device):
     """Test that probe command correctly parses arguments."""
-    runner = CtxCliRunner()
-    result = runner.invoke(main, args, catch_exceptions=False)
+    result = invoke_main(args)
 
     assert result.exit_code == 0
-    assert result.ctx is not None
-
-    flasher = result.ctx.obj["flasher"]
-    assert flasher._device == expected_device
+    assert result.flasher._device == expected_device
 
 
 @pytest.mark.parametrize(
@@ -301,13 +307,11 @@ def test_write_ieee_command_argument_parsing(
     mock_connections, args, expected_ieee, expected_force
 ):
     """Test that write-ieee command correctly parses arguments."""
-    runner = CliRunner()
-
     with patch(
         "universal_silabs_flasher.flasher.Flasher.write_emberznet_eui64",
         new_callable=AsyncMock,
     ) as mock_write:
-        result = runner.invoke(main, args, catch_exceptions=False)
+        result = invoke_main(args)
 
         assert result.exit_code == 0
 
@@ -320,15 +324,12 @@ def test_write_ieee_command_argument_parsing(
 
 def test_dump_gbl_metadata_command():
     """Test that dump-gbl-metadata command works without --device."""
-    runner = CliRunner()
-    result = runner.invoke(
-        main,
+    result = invoke_main(
         [
             "dump-gbl-metadata",
             "--firmware",
             "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-        ],
-        catch_exceptions=False,
+        ]
     )
 
     assert result.exit_code == 0
@@ -380,12 +381,12 @@ def test_dump_gbl_metadata_command():
         # Missing firmware for flash
         (
             ["--device", "/dev/ttyUSB0", "flash"],
-            "Missing option",
+            "required",
         ),
         # Missing IEEE for write-ieee
         (
             ["--device", "/dev/ttyUSB0", "write-ieee"],
-            "Missing option",
+            "required",
         ),
         # Removed --baudrate flag
         (
@@ -398,7 +399,7 @@ def test_dump_gbl_metadata_command():
                 "--firmware",
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
-            "no such option",
+            "error",
         ),
     ],
 )
@@ -406,15 +407,14 @@ def test_invalid_argument_combinations_with_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations with mocked device validator."""
-    runner = CliRunner()
-
     with patch(
-        "universal_silabs_flasher.flash.SerialPort.convert", side_effect=lambda v, *_: v
+        "universal_silabs_flasher.flash._parse_serial_port", side_effect=lambda v: v
     ):
-        result = runner.invoke(main, args)
+        result = invoke_main(args)
 
     assert result.exit_code != 0
-    assert expected_error_fragment.lower() in result.output.lower()
+    combined = result.output.lower() + result.stderr.lower()
+    assert expected_error_fragment.lower() in combined
 
 
 @pytest.mark.parametrize(
@@ -451,11 +451,11 @@ def test_invalid_argument_combinations_without_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations without mocked device validator."""
-    runner = CliRunner()
-    result = runner.invoke(main, args)
+    result = invoke_main(args)
 
     assert result.exit_code != 0
-    assert expected_error_fragment.lower() in result.output.lower()
+    combined = result.output.lower() + result.stderr.lower()
+    assert expected_error_fragment.lower() in combined
 
 
 @pytest.mark.parametrize(
@@ -512,8 +512,7 @@ def test_invalid_argument_combinations_without_mocked_device(
 )
 def test_flash_command_flags(mock_connections, args):
     """Test that flash command boolean flags are parsed correctly."""
-    runner = CliRunner()
-    result = runner.invoke(main, args, catch_exceptions=False)
+    result = invoke_main(args)
 
     assert result.exit_code == 0
 
@@ -549,11 +548,7 @@ def test_flash_command_flags(mock_connections, args):
 )
 def test_deprecated_reset_flags(mock_connections, args, expected_reset_target):
     """Test deprecated reset flags set reset targets correctly."""
-    runner = CtxCliRunner()
-    result = runner.invoke(main, args, catch_exceptions=False)
+    result = invoke_main(args)
 
     assert result.exit_code == 0
-    assert result.ctx is not None
-
-    flasher = result.ctx.obj["flasher"]
-    assert flasher._reset_targets == expected_reset_target
+    assert result.flasher._reset_targets == expected_reset_target

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -1,5 +1,6 @@
 """CLI integration tests to ensure argument parsing works correctly."""
 
+from dataclasses import dataclass
 import io
 from unittest.mock import AsyncMock, patch
 
@@ -14,11 +15,20 @@ from universal_silabs_flasher.flash import main
 from universal_silabs_flasher.flasher import Flasher
 
 
-def invoke_main(argv, *, catch_exit=True):
+@dataclass
+class Result:
+    exit_code: str | int
+    output: str
+    stderr: str
+    flasher: Flasher
+
+
+async def invoke_main(argv: list[str], *, catch_exit: bool = True) -> Result:
     """Invoke main() with the given argv, capturing stdout/stderr."""
     stdout = io.StringIO()
     stderr = io.StringIO()
-    exit_code = 0
+
+    exit_code: str | int = 0
     captured_flasher = None
 
     original_init = Flasher.__init__
@@ -28,68 +38,55 @@ def invoke_main(argv, *, catch_exit=True):
         original_init(self, **kwargs)
         captured_flasher = self
 
+    async def mock_probe_app_type(self):
+        self.app_type = ApplicationType.EZSP
+        self.app_version = None
+
     try:
         with (
             patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init),
             patch("sys.stdout", stdout),
             patch("sys.stderr", stderr),
+            patch("universal_silabs_flasher.flasher.connect_protocol"),
+            patch("universal_silabs_flasher.flasher.Flasher._connect_ezsp"),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.probe_app_type",
+                mock_probe_app_type,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.write_emberznet_eui64",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.flash_firmware",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flash._parse_serial_port",
+                side_effect=lambda v: v,
+            ),
         ):
-            main(argv)
+            await main(argv)
     except SystemExit as e:
         if not catch_exit:
             raise
+
         exit_code = e.code if e.code is not None else 0
 
-    result = type(
-        "Result",
-        (),
-        {
-            "exit_code": exit_code,
-            "output": stdout.getvalue(),
-            "stderr": stderr.getvalue(),
-            "flasher": captured_flasher,
-        },
-    )()
-    return result
-
-
-@pytest.fixture
-def mock_connections():
-    """Mock network connections to prevent actual hardware communication."""
-
-    async def mock_probe_app_type(self):
-        self.app_type = ApplicationType.EZSP
-        self.app_version = None
-
-    with (
-        patch("universal_silabs_flasher.flasher.connect_protocol"),
-        patch("universal_silabs_flasher.flasher.Flasher._connect_ezsp"),
-        patch(
-            "universal_silabs_flasher.flasher.Flasher.probe_app_type",
-            mock_probe_app_type,
-        ),
-        patch(
-            "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "universal_silabs_flasher.flasher.Flasher.write_emberznet_eui64",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "universal_silabs_flasher.flasher.Flasher.flash_firmware",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "universal_silabs_flasher.flash._parse_serial_port",
-            side_effect=lambda v: v,
-        ),
-    ):
-        yield
+    return Result(
+        exit_code=exit_code,
+        output=stdout.getvalue(),
+        stderr=stderr.getvalue(),
+        flasher=captured_flasher,
+    )
 
 
 @pytest.mark.parametrize(
@@ -240,15 +237,14 @@ def mock_connections():
         ),
     ],
 )
-def test_flash_command_argument_parsing(
-    mock_connections,
+async def test_flash_command_argument_parsing(
     args,
     expected_device,
     expected_probe_methods,
     expected_reset,
 ):
     """Test that flash command correctly parses various argument combinations."""
-    result = invoke_main(args + ["--force"])
+    result = await invoke_main(args + ["--force"])
 
     assert result.exit_code == 0
     assert result.flasher is not None
@@ -266,9 +262,9 @@ def test_flash_command_argument_parsing(
         (["--device", "socket://localhost:5000", "probe"], "socket://localhost:5000"),
     ],
 )
-def test_probe_command_argument_parsing(mock_connections, args, expected_device):
+async def test_probe_command_argument_parsing(args, expected_device):
     """Test that probe command correctly parses arguments."""
-    result = invoke_main(args)
+    result = await invoke_main(args)
 
     assert result.exit_code == 0
     assert result.flasher._device == expected_device
@@ -303,15 +299,13 @@ def test_probe_command_argument_parsing(mock_connections, args, expected_device)
         ),
     ],
 )
-def test_write_ieee_command_argument_parsing(
-    mock_connections, args, expected_ieee, expected_force
-):
+async def test_write_ieee_command_argument_parsing(args, expected_ieee, expected_force):
     """Test that write-ieee command correctly parses arguments."""
     with patch(
         "universal_silabs_flasher.flasher.Flasher.write_emberznet_eui64",
         new_callable=AsyncMock,
     ) as mock_write:
-        result = invoke_main(args)
+        result = await invoke_main(args)
 
         assert result.exit_code == 0
 
@@ -322,9 +316,9 @@ def test_write_ieee_command_argument_parsing(
         assert call_args.kwargs["force"] == expected_force
 
 
-def test_dump_gbl_metadata_command():
+async def test_dump_gbl_metadata_command():
     """Test that dump-gbl-metadata command works without --device."""
-    result = invoke_main(
+    result = await invoke_main(
         [
             "dump-gbl-metadata",
             "--firmware",
@@ -403,14 +397,14 @@ def test_dump_gbl_metadata_command():
         ),
     ],
 )
-def test_invalid_argument_combinations_with_mocked_device(
+async def test_invalid_argument_combinations_with_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations with mocked device validator."""
     with patch(
         "universal_silabs_flasher.flash._parse_serial_port", side_effect=lambda v: v
     ):
-        result = invoke_main(args)
+        result = await invoke_main(args)
 
     assert result.exit_code != 0
     combined = result.output.lower() + result.stderr.lower()
@@ -447,11 +441,11 @@ def test_invalid_argument_combinations_with_mocked_device(
         ),
     ],
 )
-def test_invalid_argument_combinations_without_mocked_device(
+async def test_invalid_argument_combinations_without_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations without mocked device validator."""
-    result = invoke_main(args)
+    result = await invoke_main(args)
 
     assert result.exit_code != 0
     combined = result.output.lower() + result.stderr.lower()
@@ -510,9 +504,9 @@ def test_invalid_argument_combinations_without_mocked_device(
         ],
     ],
 )
-def test_flash_command_flags(mock_connections, args):
+async def test_flash_command_flags(args):
     """Test that flash command boolean flags are parsed correctly."""
-    result = invoke_main(args)
+    result = await invoke_main(args)
 
     assert result.exit_code == 0
 
@@ -546,9 +540,9 @@ def test_flash_command_flags(mock_connections, args):
         ),
     ],
 )
-def test_deprecated_reset_flags(mock_connections, args, expected_reset_target):
+async def test_deprecated_reset_flags(args, expected_reset_target):
     """Test deprecated reset flags set reset targets correctly."""
-    result = invoke_main(args)
+    result = await invoke_main(args)
 
     assert result.exit_code == 0
     assert result.flasher._reset_targets == expected_reset_target

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -70,7 +70,7 @@ async def invoke_main(argv: list[str], *, catch_exit: bool = True) -> Result:
                 new_callable=AsyncMock,
             ),
             patch(
-                "universal_silabs_flasher.flash._parse_serial_port",
+                "universal_silabs_flasher.flash.parse_serial_port",
                 side_effect=lambda v: v,
             ),
         ):
@@ -402,7 +402,7 @@ async def test_invalid_argument_combinations_with_mocked_device(
 ):
     """Test invalid argument combinations with mocked device validator."""
     with patch(
-        "universal_silabs_flasher.flash._parse_serial_port", side_effect=lambda v: v
+        "universal_silabs_flasher.flash.parse_serial_port", side_effect=lambda v: v
     ):
         result = await invoke_main(args)
 

--- a/universal_silabs_flasher/__main__.py
+++ b/universal_silabs_flasher/__main__.py
@@ -1,4 +1,6 @@
+import asyncio
+
 from .flash import main
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/universal_silabs_flasher/__main__.py
+++ b/universal_silabs_flasher/__main__.py
@@ -1,6 +1,12 @@
 import asyncio
 
-from .flash import main
+from .flash import main as async_main
+
+
+def main():
+    """Main entry point."""
+    asyncio.run(async_main())
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -10,7 +10,6 @@ import re
 import sys
 import typing
 
-import click
 import crc
 import zigpy.serial
 
@@ -145,33 +144,6 @@ async def connect_protocol(port, baudrate, factory):
         yield protocol
     finally:
         await protocol.disconnect()
-
-
-class CommaSeparatedNumbers(click.ParamType):
-    """Click type to parse comma-separated numbers into a list of integers."""
-
-    name = "numbers"
-
-    def convert(
-        self, value: typing.Any, param: click.Parameter | None, ctx: click.Context
-    ) -> list[int]:
-        if isinstance(value, list):
-            return value
-
-        values = []
-
-        for v in value.split(","):
-            if not v.strip():
-                continue
-
-            try:
-                values.append(int(v, 10))
-            except ValueError:
-                raise click.BadParameter(
-                    f"Comma-separated list of numbers contains bad value: {v!r}"
-                )
-
-        return values
 
 
 def put_first(lst: list[typing.Any], elements: list[typing.Any]) -> list[typing.Any]:

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -226,6 +226,9 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         cts: bool | None = None,
         dtr: bool | None = None,
     ) -> None:
+        assert self._transport is not None
+        assert self._transport.serial is not None
+
         if rts is not None:
             self._transport.serial.rts = rts
 
@@ -242,6 +245,8 @@ class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
         cts: bool | None = None,
         dtr: bool | None = None,
     ) -> None:
+        assert self._transport is not None
+
         _LOGGER.debug(
             "Setting UART signals: rts=%s, cts=%s, dtr=%s",
             int(rts) if rts is not None else "-",

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 LOG_LEVELS = ["INFO", "DEBUG"]
 
 
-def _parse_serial_port(value: str) -> str:
+def parse_serial_port(value: str) -> str:
     path = pathlib.Path(value)
 
     if path.exists():
@@ -56,7 +56,7 @@ def _parse_serial_port(value: str) -> str:
         raise argparse.ArgumentTypeError(f"{path} does not exist")
 
 
-def _parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
+def parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
     result = []
 
     for method in value.split(","):
@@ -91,7 +91,7 @@ def _parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
     return result
 
 
-def _parse_reset_methods(value: str) -> list[ResetTarget]:
+def parse_reset_methods(value: str) -> list[ResetTarget]:
     enums = []
 
     for v in value.split(","):
@@ -106,7 +106,7 @@ def _parse_reset_methods(value: str) -> list[ResetTarget]:
     return enums
 
 
-def _parse_comma_separated_numbers(value: str) -> list[int]:
+def parse_comma_separated_numbers(value: str) -> list[int]:
     values = []
 
     for v in value.split(","):
@@ -122,7 +122,7 @@ def _parse_comma_separated_numbers(value: str) -> list[int]:
     return values
 
 
-def _parse_application_type(value: str) -> ApplicationType:
+def parse_application_type(value: str) -> ApplicationType:
     try:
         return ApplicationType(value)
     except ValueError:
@@ -130,14 +130,6 @@ def _parse_application_type(value: str) -> ApplicationType:
         raise argparse.ArgumentTypeError(
             f"{value!r} is invalid, must be one of: {', '.join(expected)}"
         )
-
-
-def _parse_bool(value: str) -> bool:
-    if value.lower() in ("true", "1", "yes"):
-        return True
-    if value.lower() in ("false", "0", "no"):
-        return False
-    raise argparse.ArgumentTypeError(f"Invalid boolean value: {value!r}")
 
 
 async def main(argv: list[str] | None = None) -> None:
@@ -150,13 +142,13 @@ async def main(argv: list[str] | None = None) -> None:
     )
     global_parser.add_argument(
         "--device",
-        type=_parse_serial_port,
+        type=parse_serial_port,
         default=argparse.SUPPRESS,
     )
     global_parser.add_argument(
         "--probe-methods",
         dest="probe_methods",
-        type=_parse_probe_methods,
+        type=parse_probe_methods,
         default=argparse.SUPPRESS,
         help=(
             "Comma-separated list of application type and baudrate pairs to use when"
@@ -169,7 +161,7 @@ async def main(argv: list[str] | None = None) -> None:
     global_parser.add_argument(
         "--bootloader-reset",
         dest="bootloader_reset",
-        type=_parse_reset_methods,
+        type=parse_reset_methods,
         default=argparse.SUPPRESS,
         help=(
             f"Reset methods to attempt when triggering bootloader mode. Multiple"
@@ -181,35 +173,35 @@ async def main(argv: list[str] | None = None) -> None:
     global_parser.add_argument(
         "--bootloader-baudrate",
         dest="deprecated_bootloader_baudrate",
-        type=_parse_comma_separated_numbers,
+        type=parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
     global_parser.add_argument(
         "--cpc-baudrate",
         dest="deprecated_cpc_baudrate",
-        type=_parse_comma_separated_numbers,
+        type=parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
     global_parser.add_argument(
         "--ezsp-baudrate",
         dest="deprecated_ezsp_baudrate",
-        type=_parse_comma_separated_numbers,
+        type=parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
     global_parser.add_argument(
         "--router-baudrate",
         dest="deprecated_router_baudrate",
-        type=_parse_comma_separated_numbers,
+        type=parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
     global_parser.add_argument(
         "--spinel-baudrate",
         dest="deprecated_spinel_baudrate",
-        type=_parse_comma_separated_numbers,
+        type=parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
@@ -217,7 +209,7 @@ async def main(argv: list[str] | None = None) -> None:
         "--probe-method",
         dest="deprecated_probe_methods",
         action="append",
-        type=_parse_application_type,
+        type=parse_application_type,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
@@ -249,7 +241,7 @@ async def main(argv: list[str] | None = None) -> None:
     )
     write_ieee_parser.add_argument(
         "--force",
-        type=_parse_bool,
+        action="store_true",
         default=False,
     )
 

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
 import logging
 import os.path
@@ -141,16 +140,20 @@ def _parse_bool(value: str) -> bool:
     raise argparse.ArgumentTypeError(f"Invalid boolean value: {value!r}")
 
 
-def _build_global_parser() -> argparse.ArgumentParser:
-    """Build a parser for global options, shared by all subcommands via parents.
-
-    All options use default=argparse.SUPPRESS so they don't overwrite values already
-    parsed by the parent parser when they appear before the subcommand name.
-    """
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument("-v", "--verbose", action="count", default=argparse.SUPPRESS)
-    p.add_argument("--device", type=_parse_serial_port, default=argparse.SUPPRESS)
-    p.add_argument(
+async def main(argv: list[str] | None = None) -> None:
+    global_parser = argparse.ArgumentParser(add_help=False)
+    global_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=argparse.SUPPRESS,
+    )
+    global_parser.add_argument(
+        "--device",
+        type=_parse_serial_port,
+        default=argparse.SUPPRESS,
+    )
+    global_parser.add_argument(
         "--probe-methods",
         dest="probe_methods",
         type=_parse_probe_methods,
@@ -163,7 +166,7 @@ def _build_global_parser() -> argparse.ArgumentParser:
             "'ezsp:115200,ezsp:460800,spinel:460800'"
         ),
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--bootloader-reset",
         dest="bootloader_reset",
         type=_parse_reset_methods,
@@ -175,42 +178,42 @@ def _build_global_parser() -> argparse.ArgumentParser:
         ),
     )
     # Deprecated flags
-    p.add_argument(
+    global_parser.add_argument(
         "--bootloader-baudrate",
         dest="deprecated_bootloader_baudrate",
         type=_parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--cpc-baudrate",
         dest="deprecated_cpc_baudrate",
         type=_parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--ezsp-baudrate",
         dest="deprecated_ezsp_baudrate",
         type=_parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--router-baudrate",
         dest="deprecated_router_baudrate",
         type=_parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--spinel-baudrate",
         dest="deprecated_spinel_baudrate",
         type=_parse_comma_separated_numbers,
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    p.add_argument(
+    global_parser.add_argument(
         "--probe-method",
         dest="deprecated_probe_methods",
         action="append",
@@ -218,11 +221,6 @@ def _build_global_parser() -> argparse.ArgumentParser:
         default=argparse.SUPPRESS,
         help=argparse.SUPPRESS,
     )
-    return p
-
-
-def main(argv: list[str] | None = None) -> None:
-    global_parser = _build_global_parser()
 
     parser = argparse.ArgumentParser(
         prog="universal-silabs-flasher",
@@ -232,46 +230,66 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # dump-gbl-metadata: --device not required
-    dump_p = subparsers.add_parser("dump-gbl-metadata", parents=[global_parser])
-    dump_p.add_argument("--firmware", type=argparse.FileType("rb"), required=True)
+    dump_parser = subparsers.add_parser("dump-gbl-metadata", parents=[global_parser])
+    dump_parser.add_argument(
+        "--firmware",
+        type=argparse.FileType("rb"),
+        required=True,
+    )
 
     # probe
     subparsers.add_parser("probe", parents=[global_parser])
 
     # write-ieee
-    write_ieee_p = subparsers.add_parser("write-ieee", parents=[global_parser])
-    write_ieee_p.add_argument("--ieee", required=True, type=zigpy.types.EUI64.convert)
-    write_ieee_p.add_argument("--force", type=_parse_bool, default=False)
+    write_ieee_parser = subparsers.add_parser("write-ieee", parents=[global_parser])
+    write_ieee_parser.add_argument(
+        "--ieee",
+        required=True,
+        type=zigpy.types.EUI64.convert,
+    )
+    write_ieee_parser.add_argument(
+        "--force",
+        type=_parse_bool,
+        default=False,
+    )
 
     # flash
-    flash_p = subparsers.add_parser("flash", parents=[global_parser])
-    flash_p.add_argument("--firmware", type=argparse.FileType("rb"), required=True)
-    flash_p.add_argument("--force", action="store_true", default=False)
-    flash_p.add_argument(
+    flash_parser = subparsers.add_parser("flash", parents=[global_parser])
+    flash_parser.add_argument(
+        "--firmware",
+        type=argparse.FileType("rb"),
+        required=True,
+    )
+    flash_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+    )
+    flash_parser.add_argument(
         "--ensure-exact-version",
         action="store_true",
         default=False,
         dest="ensure_exact_version",
     )
-    flash_p.add_argument(
+    flash_parser.add_argument(
         "--allow-downgrades",
         action="store_true",
         default=False,
         dest="allow_downgrades",
     )
-    flash_p.add_argument(
+    flash_parser.add_argument(
         "--allow-cross-flashing",
         action="store_true",
         default=False,
         dest="allow_cross_flashing",
     )
-    flash_p.add_argument(
+    flash_parser.add_argument(
         "--yellow-gpio-reset",
         action="store_true",
         default=False,
         dest="yellow_gpio_reset",
     )
-    flash_p.add_argument(
+    flash_parser.add_argument(
         "--sonoff-reset",
         action="store_true",
         default=False,
@@ -303,10 +321,9 @@ def main(argv: list[str] | None = None) -> None:
         "deprecated_spinel_baudrate",
         "deprecated_probe_methods",
     )
-    deprecated_used = any(hasattr(args, attr) for attr in _DEPRECATED_ATTRS)
     probe_methods = list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS))
 
-    if deprecated_used:
+    if any(hasattr(args, attr) for attr in _DEPRECATED_ATTRS):
         if hasattr(args, "probe_methods"):
             parser.error(
                 "`--probe-methods` cannot be used with deprecated baudrate flags"
@@ -356,13 +373,13 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     if args.command == "dump-gbl-metadata":
-        asyncio.run(_cmd_dump_gbl_metadata(args))
+        await _cmd_dump_gbl_metadata(args)
     elif args.command == "probe":
-        asyncio.run(_cmd_probe(flasher))
+        await _cmd_probe(flasher)
     elif args.command == "write-ieee":
-        asyncio.run(_cmd_write_ieee(args, flasher))
+        await _cmd_write_ieee(args, flasher)
     elif args.command == "flash":
-        asyncio.run(_cmd_flash(args, flasher, getattr(args, "verbose", 0)))
+        await _cmd_flash(args, flasher, getattr(args, "verbose", 0))
 
 
 async def _cmd_dump_gbl_metadata(args: argparse.Namespace) -> None:

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -1,22 +1,21 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
-import enum
-import functools
 import json
 import logging
 import os.path
 import pathlib
 import re
-import typing
+import sys
 import urllib.parse
 
-import click
 import coloredlogs
+import tqdm
 import zigpy.ota.validators
 import zigpy.types
 
-from .common import CommaSeparatedNumbers, put_first
+from .common import put_first
 from .const import (
     DEFAULT_BAUDRATES,
     DEFAULT_PROBE_METHODS,
@@ -32,264 +31,255 @@ _LOGGER = logging.getLogger(__name__)
 LOG_LEVELS = ["INFO", "DEBUG"]
 
 
-def click_coroutine(f: typing.Callable) -> typing.Callable:
-    @functools.wraps(f)
-    def inner(*args: tuple[typing.Any], **kwargs: typing.Any) -> typing.Any:
-        return asyncio.run(f(*args, **kwargs))
+def _parse_serial_port(value: str) -> str:
+    path = pathlib.Path(value)
 
-    return inner
+    if path.exists():
+        return value
 
+    # Windows COM port (COM10+ uses a different syntax)
+    if re.match(r"^COM[0-9]$|\\\\\.\\COM[0-9]+$", str(path)):
+        return value
 
-def click_enum_validator_factory(
-    enum_cls: type[enum.Enum],
-) -> typing.Callable[[click.Context, typing.Any, typing.Any], typing.Any]:
-    """Click enum validator factory."""
+    # Socket URI
+    try:
+        parsed = urllib.parse.urlparse(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid URI: {path}")
 
-    def validator_callback(
-        ctx: click.Context, param: click.Parameter, value: tuple[str]
-    ) -> typing.Any:
-        values = []
-
-        for v in value:
-            try:
-                values.append(enum_cls(v))
-            except ValueError:
-                expected = [m.value for m in enum_cls]
-                raise click.BadParameter(
-                    f"{v!r} is invalid, must be one of: {', '.join(expected)}"
-                )
-
-        return values
-
-    return validator_callback
+    if parsed.scheme == "socket":
+        return value
+    elif parsed.scheme != "":
+        raise argparse.ArgumentTypeError(
+            f"invalid URL scheme {parsed.scheme!r}, only `socket://` is accepted"
+        )
+    else:
+        raise argparse.ArgumentTypeError(f"{path} does not exist")
 
 
-class EnumWithSeparator(click.ParamType):
-    """Click validator that accepts enum values separated by plus signs."""
+def _parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
+    result = []
 
-    name = "enum_with_separator"
+    for method in value.split(","):
+        parts = method.split(":")
 
-    def __init__(self, enum_cls: type[enum.Enum], separator: str = ",") -> None:
-        self._enum_cls = enum_cls
-        self._separator = separator
-
-    def convert(
-        self, value: str | list[enum.Enum], param: click.Parameter, ctx: click.Context
-    ) -> list[enum.Enum]:
-        if isinstance(value, list):
-            return value
-
-        values = value.split(self._separator)
-        enums = []
-
-        for v in values:
-            try:
-                enums.append(self._enum_cls(v))
-            except ValueError:
-                expected = [m.value for m in self._enum_cls]
-                self.fail(
-                    f"{v!r} is invalid, must be one of: {', '.join(expected)}",
-                    param,
-                    ctx,
-                )
-
-        return enums
-
-
-class ClickProbeMethods(click.ParamType):
-    """Click validator that accepts probe methods in the format
-    '<application_type>:<baudrate>,<application_type>:<baudrate>,...'
-    """
-
-    name = "probe_methods"
-
-    def convert(
-        self,
-        value: str | list[tuple[ApplicationType, int]],
-        param: click.Parameter,
-        ctx: click.Context,
-    ) -> list[tuple[ApplicationType, int]]:
-        if isinstance(value, list):
-            return value
-
-        methods = value.split(",")
-        result = []
-
-        for method in methods:
-            parts = method.split(":")
-
-            if len(parts) != 2:
-                self.fail(
-                    f"invalid probe method {method!r}, must be in the format"
-                    f" '<application_type>:<baudrate>'",
-                    param,
-                    ctx,
-                )
-
-            app_type_str, baudrate_str = parts
-
-            try:
-                app_type = ApplicationType(app_type_str)
-            except ValueError:
-                expected = [m.value for m in ApplicationType]
-                self.fail(
-                    f"invalid application type {app_type_str!r}, must be one of: "
-                    f"{', '.join(expected)}",
-                    param,
-                    ctx,
-                )
-
-            try:
-                baudrate = int(baudrate_str)
-            except ValueError:
-                self.fail(
-                    f"invalid baudrate {baudrate_str!r}, must be an integer",
-                    param,
-                    ctx,
-                )
-
-            result.append((app_type, baudrate))
-
-        return result
-
-
-class SerialPort(click.ParamType):
-    """Click validator that accepts serial ports."""
-
-    name = "path_or_url"
-
-    def convert(self, value: tuple | str, param: click.Parameter, ctx: click.Context):
-        if isinstance(value, tuple):
-            return value
-
-        # File
-        path = pathlib.Path(value)
-
-        if path.exists():
-            return value
-
-        # Windows COM port (COM10+ uses a different syntax)
-        if re.match(r"^COM[0-9]$|\\\\\.\\COM[0-9]+$", str(path)):
-            return value
-
-        # Socket URI
-        try:
-            parsed = urllib.parse.urlparse(value)
-        except ValueError:
-            self.fail(f"Invalid URI: {path}", param, ctx)
-
-        if parsed.scheme == "socket":
-            return value
-        elif parsed.scheme != "":
-            self.fail(
-                f"invalid URL scheme {parsed.scheme!r}, only `socket://` is accepted",
-                param,
-                ctx,
+        if len(parts) != 2:
+            raise argparse.ArgumentTypeError(
+                f"invalid probe method {method!r}, must be in the format"
+                f" '<application_type>:<baudrate>'"
             )
-        else:
-            # Fallback
-            self.fail(f"{path} does not exist", param, ctx)
+
+        app_type_str, baudrate_str = parts
+
+        try:
+            app_type = ApplicationType(app_type_str)
+        except ValueError:
+            expected = [m.value for m in ApplicationType]
+            raise argparse.ArgumentTypeError(
+                f"invalid application type {app_type_str!r}, must be one of: "
+                f"{', '.join(expected)}"
+            )
+
+        try:
+            baudrate = int(baudrate_str)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"invalid baudrate {baudrate_str!r}, must be an integer"
+            )
+
+        result.append((app_type, baudrate))
+
+    return result
 
 
-@click.group()
-@click.option("-v", "--verbose", count=True)
-@click.option("--device", type=SerialPort())
-@click.option(
-    "--probe-methods",
-    show_default=True,
-    type=ClickProbeMethods(),
-    default=",".join(
-        f"{method.value}:{baudrate}" for method, baudrate in DEFAULT_PROBE_METHODS
-    ),
-    help=(
-        "Comma-separated list of application type and baudrate pairs to use when"
-        " probing the device. Each pair should be in the format"
-        " '<application_type>:<baudrate>'. Valid application types: "
-        f"{', '.join([m.value for m in ApplicationType])}. Example: "
-        "'ezsp:115200,ezsp:460800,spinel:460800'"
-    ),
-)
-@click.option(
-    "--bootloader-reset",
-    default=[],
-    type=EnumWithSeparator(ResetTarget),
-    help=(
-        f"Reset methods to attempt when triggering bootloader mode. Multiple methods"
-        f" can be chained by separating them with a comma. Valid values: "
-        f" {', '.join([m.value for m in ResetTarget])}"
-    ),
-)
-# Begin deprecated flags
-@click.option(
-    "--bootloader-baudrate",
-    "deprecated_bootloader_baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-@click.option(
-    "--cpc-baudrate",
-    "deprecated_cpc_baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.CPC],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-@click.option(
-    "--ezsp-baudrate",
-    "deprecated_ezsp_baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.EZSP],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-@click.option(
-    "--router-baudrate",
-    "deprecated_router_baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.ROUTER],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-@click.option(
-    "--spinel-baudrate",
-    "deprecated_spinel_baudrate",
-    default=DEFAULT_BAUDRATES[ApplicationType.SPINEL],
-    type=CommaSeparatedNumbers(),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-@click.option(
-    "--probe-method",
-    "deprecated_probe_methods",
-    multiple=True,
-    default=[m.value for m in ApplicationType],
-    callback=click_enum_validator_factory(ApplicationType),
-    show_default=True,
-    hidden=True,
-    deprecated=True,
-)
-# End deprecated flags
-@click.pass_context
-def main(
-    ctx: click.Context,
-    verbose: bool,
-    device: str,
-    probe_methods: list[tuple[ApplicationType, int]],
-    bootloader_reset: list[ResetTarget],
-    deprecated_bootloader_baudrate: list[int],
-    deprecated_cpc_baudrate: list[int],
-    deprecated_ezsp_baudrate: list[int],
-    deprecated_router_baudrate: list[int],
-    deprecated_spinel_baudrate: list[int],
-    deprecated_probe_methods: list[ApplicationType],
-) -> None:
+def _parse_reset_methods(value: str) -> list[ResetTarget]:
+    enums = []
+
+    for v in value.split(","):
+        try:
+            enums.append(ResetTarget(v))
+        except ValueError:
+            expected = [m.value for m in ResetTarget]
+            raise argparse.ArgumentTypeError(
+                f"{v!r} is invalid, must be one of: {', '.join(expected)}"
+            )
+
+    return enums
+
+
+def _parse_comma_separated_numbers(value: str) -> list[int]:
+    values = []
+
+    for v in value.split(","):
+        if not v.strip():
+            continue
+        try:
+            values.append(int(v, 10))
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"Comma-separated list of numbers contains bad value: {v!r}"
+            )
+
+    return values
+
+
+def _parse_application_type(value: str) -> ApplicationType:
+    try:
+        return ApplicationType(value)
+    except ValueError:
+        expected = [m.value for m in ApplicationType]
+        raise argparse.ArgumentTypeError(
+            f"{value!r} is invalid, must be one of: {', '.join(expected)}"
+        )
+
+
+def _parse_bool(value: str) -> bool:
+    if value.lower() in ("true", "1", "yes"):
+        return True
+    if value.lower() in ("false", "0", "no"):
+        return False
+    raise argparse.ArgumentTypeError(f"Invalid boolean value: {value!r}")
+
+
+def _build_global_parser() -> argparse.ArgumentParser:
+    """Build a parser for global options, shared by all subcommands via parents.
+
+    All options use default=argparse.SUPPRESS so they don't overwrite values already
+    parsed by the parent parser when they appear before the subcommand name.
+    """
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("-v", "--verbose", action="count", default=argparse.SUPPRESS)
+    p.add_argument("--device", type=_parse_serial_port, default=argparse.SUPPRESS)
+    p.add_argument(
+        "--probe-methods",
+        dest="probe_methods",
+        type=_parse_probe_methods,
+        default=argparse.SUPPRESS,
+        help=(
+            "Comma-separated list of application type and baudrate pairs to use when"
+            " probing the device. Each pair should be in the format"
+            " '<application_type>:<baudrate>'. Valid application types: "
+            f"{', '.join([m.value for m in ApplicationType])}. Example: "
+            "'ezsp:115200,ezsp:460800,spinel:460800'"
+        ),
+    )
+    p.add_argument(
+        "--bootloader-reset",
+        dest="bootloader_reset",
+        type=_parse_reset_methods,
+        default=argparse.SUPPRESS,
+        help=(
+            f"Reset methods to attempt when triggering bootloader mode. Multiple"
+            f" methods can be chained by separating them with a comma. Valid values:"
+            f" {', '.join([m.value for m in ResetTarget])}"
+        ),
+    )
+    # Deprecated flags
+    p.add_argument(
+        "--bootloader-baudrate",
+        dest="deprecated_bootloader_baudrate",
+        type=_parse_comma_separated_numbers,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--cpc-baudrate",
+        dest="deprecated_cpc_baudrate",
+        type=_parse_comma_separated_numbers,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--ezsp-baudrate",
+        dest="deprecated_ezsp_baudrate",
+        type=_parse_comma_separated_numbers,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--router-baudrate",
+        dest="deprecated_router_baudrate",
+        type=_parse_comma_separated_numbers,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--spinel-baudrate",
+        dest="deprecated_spinel_baudrate",
+        type=_parse_comma_separated_numbers,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--probe-method",
+        dest="deprecated_probe_methods",
+        action="append",
+        type=_parse_application_type,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    global_parser = _build_global_parser()
+
+    parser = argparse.ArgumentParser(
+        prog="universal-silabs-flasher",
+        parents=[global_parser],
+        allow_abbrev=False,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # dump-gbl-metadata: --device not required
+    dump_p = subparsers.add_parser("dump-gbl-metadata", parents=[global_parser])
+    dump_p.add_argument("--firmware", type=argparse.FileType("rb"), required=True)
+
+    # probe
+    subparsers.add_parser("probe", parents=[global_parser])
+
+    # write-ieee
+    write_ieee_p = subparsers.add_parser("write-ieee", parents=[global_parser])
+    write_ieee_p.add_argument("--ieee", required=True, type=zigpy.types.EUI64.convert)
+    write_ieee_p.add_argument("--force", type=_parse_bool, default=False)
+
+    # flash
+    flash_p = subparsers.add_parser("flash", parents=[global_parser])
+    flash_p.add_argument("--firmware", type=argparse.FileType("rb"), required=True)
+    flash_p.add_argument("--force", action="store_true", default=False)
+    flash_p.add_argument(
+        "--ensure-exact-version",
+        action="store_true",
+        default=False,
+        dest="ensure_exact_version",
+    )
+    flash_p.add_argument(
+        "--allow-downgrades",
+        action="store_true",
+        default=False,
+        dest="allow_downgrades",
+    )
+    flash_p.add_argument(
+        "--allow-cross-flashing",
+        action="store_true",
+        default=False,
+        dest="allow_cross_flashing",
+    )
+    flash_p.add_argument(
+        "--yellow-gpio-reset",
+        action="store_true",
+        default=False,
+        dest="yellow_gpio_reset",
+    )
+    flash_p.add_argument(
+        "--sonoff-reset",
+        action="store_true",
+        default=False,
+        dest="sonoff_reset",
+    )
+
+    args = parser.parse_args(argv)
+
     coloredlogs.install(
         fmt=(
             "%(asctime)s.%(msecs)03d"
@@ -297,79 +287,97 @@ def main(
             " %(name)s"
             " %(levelname)s %(message)s"
         ),
-        level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, verbose)],
+        level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, getattr(args, "verbose", 0))],
     )
 
-    # To maintain some backwards compatibility, make `--device` required only when we
-    # are actually invoking a command that interacts with a device
-    if ctx.get_parameter_source(
-        "device"
-    ) == click.core.ParameterSource.DEFAULT and ctx.invoked_subcommand not in (
-        dump_gbl_metadata.name
-    ):
-        # Replicate the "Error: Missing option" traceback
-        param = next(p for p in ctx.command.params if p.name == "device")
-        raise click.MissingParameter(ctx=ctx, param=param)
+    # --device is required for all subcommands except dump-gbl-metadata
+    if not hasattr(args, "device") and args.command != "dump-gbl-metadata":
+        parser.error("Missing option '--device'")
 
-    # Finally, deprecated baudrate baudrate flags should be converted
-    if any(
-        ctx.get_parameter_source(param) != click.core.ParameterSource.DEFAULT
-        for param in (
-            "deprecated_bootloader_baudrate",
-            "deprecated_cpc_baudrate",
-            "deprecated_ezsp_baudrate",
-            "deprecated_router_baudrate",
-            "deprecated_spinel_baudrate",
-            "deprecated_probe_methods",
-        )
-    ):
-        if (
-            ctx.get_parameter_source("probe_methods")
-            != click.core.ParameterSource.DEFAULT
-        ):
-            raise click.ClickException(
+    # Handle deprecated baudrate/probe-method flags
+    _DEPRECATED_ATTRS = (
+        "deprecated_bootloader_baudrate",
+        "deprecated_cpc_baudrate",
+        "deprecated_ezsp_baudrate",
+        "deprecated_router_baudrate",
+        "deprecated_spinel_baudrate",
+        "deprecated_probe_methods",
+    )
+    deprecated_used = any(hasattr(args, attr) for attr in _DEPRECATED_ATTRS)
+    probe_methods = list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS))
+
+    if deprecated_used:
+        if hasattr(args, "probe_methods"):
+            parser.error(
                 "`--probe-methods` cannot be used with deprecated baudrate flags"
             )
 
         baudrates = {
-            ApplicationType.GECKO_BOOTLOADER: deprecated_bootloader_baudrate,
-            ApplicationType.CPC: deprecated_cpc_baudrate,
-            ApplicationType.EZSP: deprecated_ezsp_baudrate,
-            ApplicationType.ROUTER: deprecated_router_baudrate,
-            ApplicationType.SPINEL: deprecated_spinel_baudrate,
+            ApplicationType.GECKO_BOOTLOADER: getattr(
+                args,
+                "deprecated_bootloader_baudrate",
+                DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
+            ),
+            ApplicationType.CPC: getattr(
+                args,
+                "deprecated_cpc_baudrate",
+                DEFAULT_BAUDRATES[ApplicationType.CPC],
+            ),
+            ApplicationType.EZSP: getattr(
+                args,
+                "deprecated_ezsp_baudrate",
+                DEFAULT_BAUDRATES[ApplicationType.EZSP],
+            ),
+            ApplicationType.ROUTER: getattr(
+                args,
+                "deprecated_router_baudrate",
+                DEFAULT_BAUDRATES[ApplicationType.ROUTER],
+            ),
+            ApplicationType.SPINEL: getattr(
+                args,
+                "deprecated_spinel_baudrate",
+                DEFAULT_BAUDRATES[ApplicationType.SPINEL],
+            ),
         }
 
-        probe_methods = []
+        deprecated_methods = getattr(
+            args, "deprecated_probe_methods", list(ApplicationType)
+        )
+        probe_methods = [
+            (method, baudrate)
+            for method in deprecated_methods
+            for baudrate in baudrates[method]
+        ]
 
-        for method in deprecated_probe_methods:
-            for baudrate in baudrates[method]:
-                probe_methods.append((method, baudrate))
+    flasher = Flasher(
+        device=getattr(args, "device", None),
+        probe_methods=probe_methods,
+        bootloader_reset=tuple(getattr(args, "bootloader_reset", [])),
+    )
 
-    ctx.obj = {
-        "verbosity": verbose,
-        "flasher": Flasher(
-            device=device,
-            probe_methods=probe_methods,
-            bootloader_reset=tuple(bootloader_reset),
-        ),
-    }
+    if args.command == "dump-gbl-metadata":
+        asyncio.run(_cmd_dump_gbl_metadata(args))
+    elif args.command == "probe":
+        asyncio.run(_cmd_probe(flasher))
+    elif args.command == "write-ieee":
+        asyncio.run(_cmd_write_ieee(args, flasher))
+    elif args.command == "flash":
+        asyncio.run(_cmd_flash(args, flasher, getattr(args, "verbose", 0)))
 
 
-@main.command()
-@click.pass_context
-@click.option("--firmware", type=click.File("rb"), required=True, show_default=True)
-@click_coroutine
-async def dump_gbl_metadata(ctx: click.Context, firmware: typing.BinaryIO) -> None:
-    # Parse and validate the firmware image
-    firmware_data = firmware.read()
-    firmware.close()
+async def _cmd_dump_gbl_metadata(args: argparse.Namespace) -> None:
+    firmware_data = args.firmware.read()
+    args.firmware.close()
 
     try:
         fw_image = parse_firmware_image(firmware_data)
     except zigpy.ota.validators.ValidationError as e:
-        raise click.ClickException(
-            f"{firmware.name!r} does not appear to be a valid firmware image: {e!r}"
+        print(
+            f"Error: {args.firmware.name!r} does not appear to be a valid firmware"
+            f" image: {e!r}",
+            file=sys.stderr,
         )
+        sys.exit(1)
 
     try:
         metadata = fw_image.get_nabucasa_metadata()
@@ -382,69 +390,45 @@ async def dump_gbl_metadata(ctx: click.Context, firmware: typing.BinaryIO) -> No
     print(json.dumps(metadata_obj))
 
 
-@main.command()
-@click.pass_context
-@click_coroutine
-async def probe(ctx: click.Context) -> None:
-    flasher = ctx.obj["flasher"]
-
+async def _cmd_probe(flasher: Flasher) -> None:
     try:
         await flasher.probe_app_type()
     except RuntimeError as e:
-        raise click.ClickException(str(e)) from e
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if flasher.app_type == ApplicationType.EZSP:
         _LOGGER.info("Dumping EmberZNet Config")
         try:
             await flasher.dump_emberznet_config()
         except RuntimeError as e:
-            raise click.ClickException(str(e)) from e
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
 
 
-@main.command()
-@click.pass_context
-@click.option("--ieee", required=True, type=zigpy.types.EUI64.convert)
-@click.option("--force", default=False, type=bool)
-@click_coroutine
-async def write_ieee(ctx: click.Context, ieee: zigpy.types.EUI64, force: bool) -> None:
+async def _cmd_write_ieee(args: argparse.Namespace, flasher: Flasher) -> None:
     try:
-        await ctx.obj["flasher"].write_emberznet_eui64(ieee, force=force)
+        await flasher.write_emberznet_eui64(args.ieee, force=args.force)
     except (ValueError, RuntimeError) as e:
-        raise click.ClickException(str(e)) from e
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
-@main.command()
-@click.option("--firmware", type=click.File("rb"), required=True, show_default=True)
-@click.option("--force", is_flag=True, default=False, show_default=True)
-@click.option("--ensure-exact-version", is_flag=True, default=False, show_default=True)
-@click.option("--allow-downgrades", is_flag=True, default=False, show_default=True)
-@click.option("--allow-cross-flashing", is_flag=True, default=False, show_default=True)
-@click.option("--yellow-gpio-reset", is_flag=True, default=False, show_default=True)
-@click.option("--sonoff-reset", is_flag=True, default=False, show_default=True)
-@click.pass_context
-@click_coroutine
-async def flash(
-    ctx: click.Context,
-    firmware: typing.BinaryIO,
-    force: bool,
-    ensure_exact_version: bool,
-    allow_downgrades: bool,
-    allow_cross_flashing: bool,
-    yellow_gpio_reset: bool,
-    sonoff_reset: bool,
+async def _cmd_flash(
+    args: argparse.Namespace, flasher: Flasher, verbosity: int
 ) -> None:
-    flasher = ctx.obj["flasher"]
-
-    # Parse and validate the firmware image
-    firmware_data = firmware.read()
-    firmware.close()
+    firmware_data = args.firmware.read()
+    args.firmware.close()
 
     try:
         fw_image = parse_firmware_image(firmware_data)
     except (zigpy.ota.validators.ValidationError, ValueError) as e:
-        raise click.ClickException(
-            f"{firmware.name!r} does not appear to be a valid firmware image: {e!r}"
+        print(
+            f"Error: {args.firmware.name!r} does not appear to be a valid firmware"
+            f" image: {e!r}",
+            file=sys.stderr,
         )
+        sys.exit(1)
 
     try:
         metadata = fw_image.get_nabucasa_metadata()
@@ -471,17 +455,18 @@ async def flash(
         "The '%s' flag is deprecated. Use '--bootloader-reset' "
         "instead, see --help for details."
     )
-    if yellow_gpio_reset:
+    if args.yellow_gpio_reset:
         flasher._reset_targets = [ResetTarget.YELLOW]
         _LOGGER.info(reset_msg, "--yellow-gpio-reset")
-    elif sonoff_reset:
+    elif args.sonoff_reset:
         flasher._reset_targets = [ResetTarget.RTS_DTR]
         _LOGGER.info(reset_msg, "--sonoff-reset")
 
     try:
         await flasher.probe_app_type()
     except RuntimeError as e:
-        raise click.ClickException(str(e)) from e
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if flasher.app_type == ApplicationType.EZSP:
         running_image_type = FirmwareImageType.ZIGBEE_NCP
@@ -498,7 +483,7 @@ async def flash(
         raise RuntimeError(f"Unknown application type {flasher.app_type!r}")
 
     # Ensure the firmware versions and image types are consistent
-    if not force and flasher.app_version is not None and metadata is not None:
+    if not args.force and flasher.app_version is not None and metadata is not None:
         app_version = flasher.app_version
         fw_version = metadata.get_public_version()
 
@@ -508,12 +493,14 @@ async def flash(
             and metadata.fw_type != running_image_type
         )
 
-        if is_cross_flashing and not allow_cross_flashing:
-            raise click.ClickException(
-                f"Running image type {running_image_type}"
+        if is_cross_flashing and not args.allow_cross_flashing:
+            print(
+                f"Error: Running image type {running_image_type}"
                 f" does not match firmware image type {metadata.fw_type}."
-                f" If you intend to cross-flash, run with `--allow-cross-flashing`."
+                f" If you intend to cross-flash, run with `--allow-cross-flashing`.",
+                file=sys.stderr,
             )
+            sys.exit(1)
 
         if not is_cross_flashing:
             if (
@@ -525,7 +512,7 @@ async def flash(
                     flasher.app_baudrate,
                     metadata.baudrate,
                 )
-            elif ensure_exact_version and app_version != fw_version:
+            elif args.ensure_exact_version and app_version != fw_version:
                 _LOGGER.info(
                     "Firmware version %s does not match expected version %s",
                     fw_version,
@@ -536,7 +523,7 @@ async def flash(
                     "Firmware version %s is flashed, not re-installing", app_version
                 )
                 return
-            elif not allow_downgrades and app_version > fw_version:
+            elif not args.allow_downgrades and app_version > fw_version:
                 _LOGGER.info(
                     "Firmware version %s does not upgrade current version %s",
                     fw_version,
@@ -550,18 +537,13 @@ async def flash(
 
     await flasher.enter_bootloader()
 
-    pbar = click.progressbar(
-        label=os.path.basename(firmware.name),
-        length=len(firmware_data),
-        show_eta=True,
-        show_percent=True,
-    )
-
-    # Only show the progress bar if verbose logging won't interfere
-    if ctx.obj["verbosity"] > 1:
-        pbar.is_hidden = True
-
-    with pbar:
+    with tqdm.tqdm(
+        total=len(firmware_data),
+        desc=os.path.basename(args.firmware.name),
+        unit="B",
+        unit_scale=True,
+        disable=verbosity > 1,
+    ) as pbar:
         try:
             await flasher.flash_firmware(
                 fw_image,
@@ -569,7 +551,9 @@ async def flash(
                 progress_callback=lambda current, _: pbar.update(XMODEM_BLOCK_SIZE),
             )
         except ReceiverCancelled:
-            raise click.ClickException(
-                "Firmware image was rejected by the device. Ensure this is the correct"
-                " image for this device."
+            print(
+                "Error: Firmware image was rejected by the device. Ensure this is"
+                " the correct image for this device.",
+                file=sys.stderr,
             )
+            sys.exit(1)

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -117,11 +117,11 @@ class GeckoBootloaderProtocol(SerialProtocol):
         self._xmodem_completion_future: asyncio.Future[None] | None = None
         self._xmodem_timeout_handle: asyncio.TimerHandle | None = None
 
-    def connection_made(self, transport: asyncio.Transport) -> None:
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
         super().connection_made(transport)
         self.loop = asyncio.get_running_loop()
 
-    def connection_lost(self, exc: Exception | None) -> None:
+    def connection_lost(self, exc: BaseException | None) -> None:
         super().connection_lost(exc)
         self._state_machine.cancel_all_futures(
             exc or RuntimeError("Connection has been lost")


### PR DESCRIPTION
Click has a lot of random quirks and doesn't really offer anything that `argparse` can't do these days. It also poses version compatibility issues when installed in current versions of Home Assistant core.

This PR migrates us to plain argparse. Parsing semantics should stay the same for all CLI use of this package.