### PR TITLE
Remove `--force` + other version check flags and drop deprecated flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ options:
 ## Flashing firmware
 For safety, firmware GBL image files are validated and their checksums verified both before sending, and by the device bootloader itself.
 
-In addition to validating the firmware image, the version number of the firmware image currently running on the device is read.
-
- - If the provided firmware image type does not match the running image type, the firmware will not be flashed. Cross-flashing can be enabled with `--allow-cross-flashing`.
- - If the provided firmware image is a lower version than the currently running image, the downgrade will not be allowed. Downgrades can be enabled with `--allow-downgrades`.
- - To always upgrade/downgrade firmware to a specific version (i.e. as the entry point for an addon bundling firmware), use `--ensure-exact-version`.
- - All of the above logic can be skipped with `--force`.
-
 ### Yellow
 The Yellow's bootloader can always be activated with the `--bootloader-reset yellow` option:
 

--- a/tests/test_flash.py
+++ b/tests/test_flash.py
@@ -3,27 +3,7 @@ from argparse import ArgumentTypeError
 import pytest
 
 from universal_silabs_flasher.const import ResetTarget
-from universal_silabs_flasher.flash import parse_reset_methods, parse_serial_port
-
-
-def test_click_serialport_validation():
-    assert parse_serial_port("/dev/null") == "/dev/null"
-    assert parse_serial_port("socket://1.2.3.4") == "socket://1.2.3.4"
-    assert parse_serial_port("COM1") == "COM1"
-    assert parse_serial_port("\\\\.\\COM123") == "\\\\.\\COM123"
-
-    with pytest.raises(ArgumentTypeError):
-        assert parse_serial_port("COM10")
-
-    with pytest.raises(ArgumentTypeError) as exc_info:
-        assert parse_serial_port("http://1.2.3.4")
-
-    assert "invalid URL scheme" in str(exc_info.value)
-
-    with pytest.raises(ArgumentTypeError) as exc_info:
-        assert parse_serial_port("/dev/serial/by-id/does-not-exist")
-
-    assert "does not exist" in str(exc_info.value)
+from universal_silabs_flasher.flash import parse_reset_methods
 
 
 def test_enum_with_separator_single_value() -> None:

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -1,6 +1,5 @@
 """CLI integration tests to ensure argument parsing works correctly."""
 
-from contextlib import ExitStack
 from dataclasses import dataclass
 import io
 from unittest.mock import AsyncMock, patch
@@ -24,9 +23,7 @@ class Result:
     flasher: Flasher
 
 
-async def invoke_main(
-    argv: list[str], *, catch_exit: bool = True, mock_serial_port: bool = True
-) -> Result:
+async def invoke_main(argv: list[str]) -> Result:
     """Invoke main() with the given argv, capturing stdout/stderr."""
     stdout = io.StringIO()
     stderr = io.StringIO()
@@ -46,48 +43,29 @@ async def invoke_main(
         self.app_version = None
 
     try:
-        with ExitStack() as stack:
-            stack.enter_context(
-                patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init)
-            )
-            stack.enter_context(patch("sys.stdout", stdout))
-            stack.enter_context(patch("sys.stderr", stderr))
-            stack.enter_context(
-                patch(
-                    "universal_silabs_flasher.flasher.Flasher.probe_app_type",
-                    mock_probe_app_type,
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
-                    new_callable=AsyncMock,
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
-                    new_callable=AsyncMock,
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "universal_silabs_flasher.flasher.Flasher.flash_firmware",
-                    new_callable=AsyncMock,
-                )
-            )
-            if mock_serial_port:
-                stack.enter_context(
-                    patch(
-                        "universal_silabs_flasher.flash.parse_serial_port",
-                        side_effect=lambda v: v,
-                    )
-                )
+        with (
+            patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init),
+            patch("sys.stdout", stdout),
+            patch("sys.stderr", stderr),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.probe_app_type",
+                mock_probe_app_type,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.dump_emberznet_config",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "universal_silabs_flasher.flasher.Flasher.flash_firmware",
+                new_callable=AsyncMock,
+            ),
+        ):
             await main(argv)
     except SystemExit as e:
-        if not catch_exit:
-            raise
-
         exit_code = e.code if e.code is not None else 0
 
     return Result(
@@ -126,79 +104,6 @@ async def invoke_main(
             ],
             "/dev/ttyUSB1",
             DEFAULT_PROBE_METHODS,
-            [],
-        ),
-        # With custom bootloader baudrate (deprecated flag)
-        (
-            [
-                "--device",
-                "/dev/ttyUSB0",
-                "--bootloader-baudrate",
-                "115200",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            ],
-            "/dev/ttyUSB0",
-            [
-                (ApplicationType.GECKO_BOOTLOADER, 115200),
-                (ApplicationType.CPC, 460800),
-                (ApplicationType.CPC, 115200),
-                (ApplicationType.CPC, 230400),
-                (ApplicationType.EZSP, 115200),
-                (ApplicationType.EZSP, 460800),
-                (ApplicationType.ROUTER, 115200),
-                (ApplicationType.SPINEL, 460800),
-            ],
-            [],
-        ),
-        # With multiple custom baudrates (deprecated flags)
-        (
-            [
-                "--device",
-                "/dev/ttyUSB0",
-                "--bootloader-baudrate",
-                "115200,230400",
-                "--ezsp-baudrate",
-                "115200",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            ],
-            "/dev/ttyUSB0",
-            [
-                (ApplicationType.GECKO_BOOTLOADER, 115200),
-                (ApplicationType.GECKO_BOOTLOADER, 230400),
-                (ApplicationType.CPC, 460800),
-                (ApplicationType.CPC, 115200),
-                (ApplicationType.CPC, 230400),
-                (ApplicationType.EZSP, 115200),
-                (ApplicationType.ROUTER, 115200),
-                (ApplicationType.SPINEL, 460800),
-            ],
-            [],
-        ),
-        # With custom probe methods (deprecated flag)
-        (
-            [
-                "--device",
-                "/dev/ttyUSB0",
-                "--probe-method",
-                "ezsp",
-                "--probe-method",
-                "cpc",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            ],
-            "/dev/ttyUSB0",
-            [
-                (ApplicationType.EZSP, 115200),
-                (ApplicationType.EZSP, 460800),
-                (ApplicationType.CPC, 460800),
-                (ApplicationType.CPC, 115200),
-                (ApplicationType.CPC, 230400),
-            ],
             [],
         ),
         # With single bootloader reset method
@@ -253,7 +158,7 @@ async def test_flash_command_argument_parsing(
     expected_reset,
 ):
     """Test that flash command correctly parses various argument combinations."""
-    result = await invoke_main(args + ["--force"])
+    result = await invoke_main(args)
 
     assert result.exit_code == 0
     assert result.flasher is not None
@@ -409,148 +314,8 @@ async def test_invalid_argument_combinations_with_mocked_device(
     args, expected_error_fragment
 ):
     """Test invalid argument combinations with mocked device validator."""
-    with patch(
-        "universal_silabs_flasher.flash.parse_serial_port", side_effect=lambda v: v
-    ):
-        result = await invoke_main(args)
+    result = await invoke_main(args)
 
     assert result.exit_code != 0
     combined = result.output.lower() + result.stderr.lower()
     assert expected_error_fragment.lower() in combined
-
-
-@pytest.mark.parametrize(
-    "args,expected_error_fragment",
-    [
-        # Invalid device scheme
-        (
-            [
-                "--device",
-                "http://example.com",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            ],
-            "invalid URL scheme",
-        ),
-        # Missing device for flash
-        (
-            [
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            ],
-            "Missing option",
-        ),
-        # Missing device for probe
-        (
-            ["probe"],
-            "Missing option",
-        ),
-    ],
-)
-async def test_invalid_argument_combinations_without_mocked_device(
-    args, expected_error_fragment
-):
-    """Test invalid argument combinations without mocked device validator."""
-    result = await invoke_main(args, mock_serial_port=False)
-
-    assert result.exit_code != 0
-    combined = result.output.lower() + result.stderr.lower()
-    assert expected_error_fragment.lower() in combined
-
-
-@pytest.mark.parametrize(
-    "args",
-    [
-        [
-            "-v",
-            "--device",
-            "/dev/ttyUSB0",
-            "flash",
-            "--firmware",
-            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            "--force",
-        ],
-        [
-            "-vv",
-            "--device",
-            "/dev/ttyUSB0",
-            "flash",
-            "--firmware",
-            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            "--force",
-            "--ensure-exact-version",
-        ],
-        [
-            "--device",
-            "/dev/ttyUSB0",
-            "flash",
-            "--firmware",
-            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            "--force",
-            "--allow-downgrades",
-        ],
-        [
-            "--device",
-            "/dev/ttyUSB0",
-            "flash",
-            "--firmware",
-            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            "--force",
-            "--allow-cross-flashing",
-        ],
-        [
-            "--device",
-            "/dev/ttyUSB0",
-            "flash",
-            "--firmware",
-            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-            "--force",
-            "--allow-downgrades",
-            "--ensure-exact-version",
-        ],
-    ],
-)
-async def test_flash_command_flags(args):
-    """Test that flash command boolean flags are parsed correctly."""
-    result = await invoke_main(args)
-
-    assert result.exit_code == 0
-
-
-@pytest.mark.parametrize(
-    "args,expected_reset_target",
-    [
-        (
-            [
-                "--device",
-                "/dev/ttyUSB0",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-                "--force",
-                "--yellow-gpio-reset",
-            ],
-            [ResetTarget.YELLOW],
-        ),
-        (
-            [
-                "--device",
-                "/dev/ttyUSB0",
-                "flash",
-                "--firmware",
-                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
-                "--force",
-                "--sonoff-reset",
-            ],
-            [ResetTarget.RTS_DTR],
-        ),
-    ],
-)
-async def test_deprecated_reset_flags(args, expected_reset_target):
-    """Test deprecated reset flags set reset targets correctly."""
-    result = await invoke_main(args)
-
-    assert result.exit_code == 0
-    assert result.flasher._reset_targets == expected_reset_target

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -55,15 +55,6 @@ DEFAULT_PROBE_METHODS = (
     (ApplicationType.ROUTER, 115200),
 )
 
-# Backwards compat
-DEFAULT_BAUDRATES: dict[ApplicationType, list[int]] = {}
-
-for method, baudrate in DEFAULT_PROBE_METHODS:
-    if method not in DEFAULT_BAUDRATES:
-        DEFAULT_BAUDRATES[method] = []
-
-    DEFAULT_BAUDRATES[method].append(baudrate)
-
 
 class ResetTarget(enum.Enum):
     YELLOW = "yellow"

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -4,10 +4,7 @@ import argparse
 import json
 import logging
 import os.path
-import pathlib
-import re
 import sys
-import urllib.parse
 
 import coloredlogs
 import tqdm
@@ -16,7 +13,6 @@ import zigpy.types
 
 from .common import put_first
 from .const import (
-    DEFAULT_BAUDRATES,
     DEFAULT_PROBE_METHODS,
     FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
     ApplicationType,
@@ -28,32 +24,6 @@ from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
 _LOGGER = logging.getLogger(__name__)
 LOG_LEVELS = ["INFO", "DEBUG"]
-
-
-def parse_serial_port(value: str) -> str:
-    path = pathlib.Path(value)
-
-    if path.exists():
-        return value
-
-    # Windows COM port (COM10+ uses a different syntax)
-    if re.match(r"^COM[0-9]$|\\\\\.\\COM[0-9]+$", str(path)):
-        return value
-
-    # Socket URI
-    try:
-        parsed = urllib.parse.urlparse(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"Invalid URI: {path}")
-
-    if parsed.scheme == "socket":
-        return value
-    elif parsed.scheme != "":
-        raise argparse.ArgumentTypeError(
-            f"invalid URL scheme {parsed.scheme!r}, only `socket://` is accepted"
-        )
-    else:
-        raise argparse.ArgumentTypeError(f"{path} does not exist")
 
 
 def parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
@@ -106,32 +76,6 @@ def parse_reset_methods(value: str) -> list[ResetTarget]:
     return enums
 
 
-def parse_comma_separated_numbers(value: str) -> list[int]:
-    values = []
-
-    for v in value.split(","):
-        if not v.strip():
-            continue
-        try:
-            values.append(int(v, 10))
-        except ValueError:
-            raise argparse.ArgumentTypeError(
-                f"Comma-separated list of numbers contains bad value: {v!r}"
-            )
-
-    return values
-
-
-def parse_application_type(value: str) -> ApplicationType:
-    try:
-        return ApplicationType(value)
-    except ValueError:
-        expected = [m.value for m in ApplicationType]
-        raise argparse.ArgumentTypeError(
-            f"{value!r} is invalid, must be one of: {', '.join(expected)}"
-        )
-
-
 async def main(argv: list[str] | None = None) -> None:
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument(
@@ -142,7 +86,7 @@ async def main(argv: list[str] | None = None) -> None:
     )
     global_parser.add_argument(
         "--device",
-        type=parse_serial_port,
+        type=str,
         default=argparse.SUPPRESS,
     )
     global_parser.add_argument(
@@ -168,50 +112,6 @@ async def main(argv: list[str] | None = None) -> None:
             f" methods can be chained by separating them with a comma. Valid values:"
             f" {', '.join([m.value for m in ResetTarget])}"
         ),
-    )
-    # Deprecated flags
-    global_parser.add_argument(
-        "--bootloader-baudrate",
-        dest="deprecated_bootloader_baudrate",
-        type=parse_comma_separated_numbers,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
-    global_parser.add_argument(
-        "--cpc-baudrate",
-        dest="deprecated_cpc_baudrate",
-        type=parse_comma_separated_numbers,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
-    global_parser.add_argument(
-        "--ezsp-baudrate",
-        dest="deprecated_ezsp_baudrate",
-        type=parse_comma_separated_numbers,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
-    global_parser.add_argument(
-        "--router-baudrate",
-        dest="deprecated_router_baudrate",
-        type=parse_comma_separated_numbers,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
-    global_parser.add_argument(
-        "--spinel-baudrate",
-        dest="deprecated_spinel_baudrate",
-        type=parse_comma_separated_numbers,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
-    global_parser.add_argument(
-        "--probe-method",
-        dest="deprecated_probe_methods",
-        action="append",
-        type=parse_application_type,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
     )
 
     parser = argparse.ArgumentParser(
@@ -252,45 +152,6 @@ async def main(argv: list[str] | None = None) -> None:
         type=argparse.FileType("rb"),
         required=True,
     )
-    flash_parser.add_argument(
-        "--force",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
-    )
-    flash_parser.add_argument(
-        "--ensure-exact-version",
-        action="store_true",
-        default=False,
-        dest="ensure_exact_version",
-        help=argparse.SUPPRESS,
-    )
-    flash_parser.add_argument(
-        "--allow-downgrades",
-        action="store_true",
-        default=False,
-        dest="allow_downgrades",
-        help=argparse.SUPPRESS,
-    )
-    flash_parser.add_argument(
-        "--allow-cross-flashing",
-        action="store_true",
-        default=False,
-        dest="allow_cross_flashing",
-        help=argparse.SUPPRESS,
-    )
-    flash_parser.add_argument(
-        "--yellow-gpio-reset",
-        action="store_true",
-        default=False,
-        dest="yellow_gpio_reset",
-    )
-    flash_parser.add_argument(
-        "--sonoff-reset",
-        action="store_true",
-        default=False,
-        dest="sonoff_reset",
-    )
 
     args = parser.parse_args(argv)
 
@@ -308,65 +169,9 @@ async def main(argv: list[str] | None = None) -> None:
     if not hasattr(args, "device") and args.command != "dump-gbl-metadata":
         parser.error("Missing option '--device'")
 
-    # Handle deprecated baudrate/probe-method flags
-    _DEPRECATED_ATTRS = (
-        "deprecated_bootloader_baudrate",
-        "deprecated_cpc_baudrate",
-        "deprecated_ezsp_baudrate",
-        "deprecated_router_baudrate",
-        "deprecated_spinel_baudrate",
-        "deprecated_probe_methods",
-    )
-    probe_methods = list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS))
-
-    if any(hasattr(args, attr) for attr in _DEPRECATED_ATTRS):
-        if hasattr(args, "probe_methods"):
-            parser.error(
-                "`--probe-methods` cannot be used with deprecated baudrate flags"
-            )
-
-        baudrates = {
-            ApplicationType.GECKO_BOOTLOADER: getattr(
-                args,
-                "deprecated_bootloader_baudrate",
-                DEFAULT_BAUDRATES[ApplicationType.GECKO_BOOTLOADER],
-            ),
-            ApplicationType.CPC: getattr(
-                args,
-                "deprecated_cpc_baudrate",
-                DEFAULT_BAUDRATES[ApplicationType.CPC],
-            ),
-            ApplicationType.EZSP: getattr(
-                args,
-                "deprecated_ezsp_baudrate",
-                DEFAULT_BAUDRATES[ApplicationType.EZSP],
-            ),
-            ApplicationType.ROUTER: getattr(
-                args,
-                "deprecated_router_baudrate",
-                DEFAULT_BAUDRATES[ApplicationType.ROUTER],
-            ),
-            ApplicationType.SPINEL: getattr(
-                args,
-                "deprecated_spinel_baudrate",
-                DEFAULT_BAUDRATES[ApplicationType.SPINEL],
-            ),
-        }
-
-        deprecated_methods = getattr(
-            args,
-            "deprecated_probe_methods",
-            [t for t in ApplicationType if t != ApplicationType.ZWAVE],
-        )
-        probe_methods = [
-            (method, baudrate)
-            for method in deprecated_methods
-            for baudrate in baudrates[method]
-        ]
-
     flasher = Flasher(
         device=getattr(args, "device", None),
-        probe_methods=probe_methods,
+        probe_methods=list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS)),
         bootloader_reset=tuple(getattr(args, "bootloader_reset", [])),
     )
 
@@ -465,37 +270,11 @@ async def _cmd_flash(
             flasher._probe_methods, [(app_type, metadata.baudrate)]
         )
 
-    # Maintain backward compatibility with the deprecated reset flags
-    reset_msg = (
-        "The '%s' flag is deprecated. Use '--bootloader-reset' "
-        "instead, see --help for details."
-    )
-    if args.yellow_gpio_reset:
-        flasher._reset_targets = [ResetTarget.YELLOW]
-        _LOGGER.info(reset_msg, "--yellow-gpio-reset")
-    elif args.sonoff_reset:
-        flasher._reset_targets = [ResetTarget.RTS_DTR]
-        _LOGGER.info(reset_msg, "--sonoff-reset")
-
     try:
         await flasher.probe_app_type()
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    _DEPRECATED_FLASH_FLAGS = {
-        "--force": args.force,
-        "--ensure-exact-version": args.ensure_exact_version,
-        "--allow-downgrades": args.allow_downgrades,
-        "--allow-cross-flashing": args.allow_cross_flashing,
-    }
-    for flag, used in _DEPRECATED_FLASH_FLAGS.items():
-        if used:
-            _LOGGER.warning(
-                "The '%s' flag is deprecated and has no effect. Firmware will always"
-                " be flashed unconditionally.",
-                flag,
-            )
 
     await flasher.enter_bootloader()
 

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -22,7 +22,7 @@ from .const import (
     ApplicationType,
     ResetTarget,
 )
-from .firmware import FirmwareImageType, parse_firmware_image
+from .firmware import parse_firmware_image
 from .flasher import Flasher
 from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
@@ -256,24 +256,28 @@ async def main(argv: list[str] | None = None) -> None:
         "--force",
         action="store_true",
         default=False,
+        help=argparse.SUPPRESS,
     )
     flash_parser.add_argument(
         "--ensure-exact-version",
         action="store_true",
         default=False,
         dest="ensure_exact_version",
+        help=argparse.SUPPRESS,
     )
     flash_parser.add_argument(
         "--allow-downgrades",
         action="store_true",
         default=False,
         dest="allow_downgrades",
+        help=argparse.SUPPRESS,
     )
     flash_parser.add_argument(
         "--allow-cross-flashing",
         action="store_true",
         default=False,
         dest="allow_cross_flashing",
+        help=argparse.SUPPRESS,
     )
     flash_parser.add_argument(
         "--yellow-gpio-reset",
@@ -479,73 +483,18 @@ async def _cmd_flash(
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    if flasher.app_type == ApplicationType.EZSP:
-        running_image_type = FirmwareImageType.ZIGBEE_NCP
-    elif flasher.app_type == ApplicationType.ROUTER:
-        running_image_type = FirmwareImageType.ZIGBEE_ROUTER
-    elif flasher.app_type == ApplicationType.SPINEL:
-        running_image_type = FirmwareImageType.OPENTHREAD_RCP
-    elif flasher.app_type == ApplicationType.CPC:
-        # TODO: how do you distinguish RCP_UART_802154 from ZIGBEE_NCP_RCP_UART_802154?
-        running_image_type = FirmwareImageType.MULTIPAN
-    elif flasher.app_type == ApplicationType.ZWAVE:
-        running_image_type = FirmwareImageType.ZWAVE_NCP
-    elif flasher.app_type == ApplicationType.GECKO_BOOTLOADER:
-        running_image_type = None
-    else:
-        raise RuntimeError(f"Unknown application type {flasher.app_type!r}")
-
-    # Ensure the firmware versions and image types are consistent
-    if not args.force and flasher.app_version is not None and metadata is not None:
-        app_version = flasher.app_version
-        fw_version = metadata.get_public_version()
-
-        is_cross_flashing = (
-            metadata.fw_type is not None
-            and running_image_type is not None
-            and metadata.fw_type != running_image_type
-        )
-
-        if is_cross_flashing and not args.allow_cross_flashing:
-            print(
-                f"Error: Running image type {running_image_type}"
-                f" does not match firmware image type {metadata.fw_type}."
-                f" If you intend to cross-flash, run with `--allow-cross-flashing`.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        if not is_cross_flashing:
-            if (
-                metadata.baudrate is not None
-                and metadata.baudrate != flasher.app_baudrate
-            ):
-                _LOGGER.info(
-                    "Firmware baudrate %s differs from expected baudrate %s",
-                    flasher.app_baudrate,
-                    metadata.baudrate,
-                )
-            elif args.ensure_exact_version and app_version != fw_version:
-                _LOGGER.info(
-                    "Firmware version %s does not match expected version %s",
-                    fw_version,
-                    app_version,
-                )
-            elif app_version.compatible_with(fw_version):
-                _LOGGER.info(
-                    "Firmware version %s is flashed, not re-installing", app_version
-                )
-                return
-            elif not args.allow_downgrades and app_version > fw_version:
-                _LOGGER.info(
-                    "Firmware version %s does not upgrade current version %s",
-                    fw_version,
-                    app_version,
-                )
-                return
-        else:
-            _LOGGER.info(
-                "Cross-flashing from %s to %s", running_image_type, metadata.fw_type
+    _DEPRECATED_FLASH_FLAGS = {
+        "--force": args.force,
+        "--ensure-exact-version": args.ensure_exact_version,
+        "--allow-downgrades": args.allow_downgrades,
+        "--allow-cross-flashing": args.allow_cross_flashing,
+    }
+    for flag, used in _DEPRECATED_FLASH_FLAGS.items():
+        if used:
+            _LOGGER.warning(
+                "The '%s' flag is deprecated and has no effect. Firmware will always"
+                " be flashed unconditionally.",
+                flag,
             )
 
     await flasher.enter_bootloader()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -447,8 +447,8 @@ async def _cmd_flash(
 
     try:
         metadata = fw_image.get_nabucasa_metadata()
-    except Exception:
-        _LOGGER.info("Failed to read firmware metadata: {exc!r}")
+    except Exception as exc:
+        _LOGGER.info(f"Failed to read firmware metadata: {exc!r}")
         metadata = None
     else:
         _LOGGER.info("Extracted GBL metadata: %s", metadata)


### PR DESCRIPTION
We no longer use universal-silabs-flasher as an entrypoint for any addon so there is no point in ensuring the firmware isn't downgraded, etc. These options will no longer do anything.