### PR TITLE
Support http and https URLs, including ZIPs

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pytest-asyncio
 pytest-cov
 pytest-timeout
 tomli
+aioresponses

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -2,8 +2,11 @@
 
 from dataclasses import dataclass
 import io
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
+import zipfile
 
+from aioresponses import aioresponses
 import pytest
 
 from universal_silabs_flasher.const import (
@@ -13,6 +16,9 @@ from universal_silabs_flasher.const import (
 )
 from universal_silabs_flasher.flash import main
 from universal_silabs_flasher.flasher import Flasher
+
+FIRMWARE_URL = "https://example.com/firmware/skyconnect_zigbee_ncp_7.4.4.0.gbl"
+FIRMWARE_PATH = Path("tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl")
 
 
 @dataclass
@@ -319,3 +325,55 @@ async def test_invalid_argument_combinations_with_mocked_device(
     assert result.exit_code != 0
     combined = result.output.lower() + result.stderr.lower()
     assert expected_error_fragment.lower() in combined
+
+
+def make_zip(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+
+    return buf.getvalue()
+
+
+async def test_firmware_download_gbl():
+    """A plain .gbl downloaded over HTTP is flashed successfully."""
+    with aioresponses() as m:
+        m.get(FIRMWARE_URL, status=200, body=FIRMWARE_PATH.read_bytes())
+        result = await invoke_main(
+            ["--device", "/dev/ttyUSB0", "flash", "--firmware", FIRMWARE_URL]
+        )
+
+    assert result.exit_code == 0
+
+
+async def test_firmware_download_zip_picks_gbl():
+    """A ZIP with a .gbl and another file: the .gbl entry is extracted and flashed."""
+    zip_url = "https://example.com/firmware/update.zip"
+    zip_bytes = make_zip(
+        {
+            "readme.txt": b"hello",
+            "firmware.gbl": FIRMWARE_PATH.read_bytes(),
+        }
+    )
+
+    with aioresponses() as m:
+        m.get(zip_url, status=200, body=zip_bytes)
+        result = await invoke_main(
+            ["--device", "/dev/ttyUSB0", "flash", "--firmware", zip_url]
+        )
+
+    assert result.exit_code == 0
+
+
+async def test_firmware_download_failure():
+    """An HTTP error status is reported as a CLI error."""
+    with aioresponses() as m:
+        m.get(FIRMWARE_URL, status=404)
+        result = await invoke_main(
+            ["--device", "/dev/ttyUSB0", "flash", "--firmware", FIRMWARE_URL]
+        )
+
+    assert result.exit_code != 0
+    assert "error" in result.stderr.lower()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+from io import BytesIO
 import json
 import logging
 import os.path
+from pathlib import Path
 import sys
+import zipfile
 
+import aiohttp
 import coloredlogs
 import tqdm
 import zigpy.ota.validators
@@ -24,6 +29,35 @@ from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
 _LOGGER = logging.getLogger(__name__)
 LOG_LEVELS = ["INFO", "DEBUG"]
+
+
+async def _load_firmware_data(source: str) -> tuple[bytes, str]:
+    """Load firmware bytes from a local file path or an HTTP/HTTPS URL.
+
+    If the loaded file is a ZIP archive, the first .gbl entry is used;
+    falling back to the very first entry if none have a .gbl extension.
+    """
+    if source.startswith(("http://", "https://")):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(source, allow_redirects=True) as resp:
+                resp.raise_for_status()
+                data = await resp.read()
+    else:
+        data = await asyncio.to_thread(Path(source).read_bytes)
+
+    data_io = BytesIO(data)
+
+    if zipfile.is_zipfile(data_io):
+        with zipfile.ZipFile(data_io) as zf:
+            names = zf.namelist()
+
+            # Prefer the first .gbl file, if one exists
+            entry = next((n for n in names if n.lower().endswith(".gbl")), names[0])
+            _LOGGER.debug("Extracting %r from ZIP archive %r", entry, source)
+
+            return zf.read(entry), entry
+
+    return data, source
 
 
 def parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
@@ -125,7 +159,6 @@ async def main(argv: list[str] | None = None) -> None:
     dump_parser = subparsers.add_parser("dump-gbl-metadata", parents=[global_parser])
     dump_parser.add_argument(
         "--firmware",
-        type=argparse.FileType("rb"),
         required=True,
     )
 
@@ -149,7 +182,6 @@ async def main(argv: list[str] | None = None) -> None:
     flash_parser = subparsers.add_parser("flash", parents=[global_parser])
     flash_parser.add_argument(
         "--firmware",
-        type=argparse.FileType("rb"),
         required=True,
     )
 
@@ -186,14 +218,17 @@ async def main(argv: list[str] | None = None) -> None:
 
 
 async def _cmd_dump_gbl_metadata(args: argparse.Namespace) -> None:
-    firmware_data = args.firmware.read()
-    args.firmware.close()
+    try:
+        firmware_data, firmware_name = await _load_firmware_data(args.firmware)
+    except (OSError, aiohttp.ClientResponseError) as e:
+        print(f"Error: Failed to load firmware {args.firmware!r}: {e}", file=sys.stderr)
+        sys.exit(1)
 
     try:
         fw_image = parse_firmware_image(firmware_data)
     except zigpy.ota.validators.ValidationError as e:
         print(
-            f"Error: {args.firmware.name!r} does not appear to be a valid firmware"
+            f"Error: {firmware_name!r} does not appear to be a valid firmware"
             f" image: {e!r}",
             file=sys.stderr,
         )
@@ -237,14 +272,17 @@ async def _cmd_write_ieee(args: argparse.Namespace, flasher: Flasher) -> None:
 async def _cmd_flash(
     args: argparse.Namespace, flasher: Flasher, verbosity: int
 ) -> None:
-    firmware_data = args.firmware.read()
-    args.firmware.close()
+    try:
+        firmware_data, firmware_name = await _load_firmware_data(args.firmware)
+    except (OSError, aiohttp.ClientResponseError) as e:
+        print(f"Error: Failed to load firmware {args.firmware!r}: {e}", file=sys.stderr)
+        sys.exit(1)
 
     try:
         fw_image = parse_firmware_image(firmware_data)
     except (zigpy.ota.validators.ValidationError, ValueError) as e:
         print(
-            f"Error: {args.firmware.name!r} does not appear to be a valid firmware"
+            f"Error: {firmware_name!r} does not appear to be a valid firmware"
             f" image: {e!r}",
             file=sys.stderr,
         )
@@ -280,7 +318,7 @@ async def _cmd_flash(
 
     with tqdm.tqdm(
         total=len(firmware_data),
-        desc=os.path.basename(args.firmware.name),
+        desc=os.path.basename(firmware_name),
         unit="B",
         unit_scale=True,
         disable=verbosity > 1,


### PR DESCRIPTION
To simplify the firmware flashing ~addon~ app and testing, we can autodetect `http://` and `https://` URLs and optionally extract ZIP archives (to support flashing straight from CI artifact archives).