### PR TITLE
Add device-specific flashers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
         args: ["--toml", "pyproject.toml"]
   
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.3
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
@@ -15,7 +15,7 @@ repos:
         args: ["--config", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ options:
                         Each pair should be in the format '<application_type>:<baudrate>'. Valid application types:
                         bootloader, cpc, ezsp, spinel, router. Example: 'ezsp:115200,ezsp:460800,spinel:460800'
   --bootloader-reset BOOTLOADER_RESET
-                        Reset methods to attempt when triggering bootloader mode. Multiple methods can be chained by
-                        separating them with a comma. Valid values: yellow, ihost, slzb07, rts_dtr, baudrate
+                         Reset methods to attempt when triggering bootloader mode. Multiple methods can be chained by
+                         separating them with a comma. Valid values: yellow, ihost, slzb07, rts_dtr, baudrate
 ```
+
+For `flash`, you can also pass `--profile {zbt2}` to use a predefined device profile.
+`--profile` cannot be combined with `--probe-methods` or `--bootloader-reset`.
 
 ## Flashing firmware
 For safety, firmware GBL image files are validated and their checksums verified both before sending, and by the device bootloader itself.
@@ -54,12 +57,13 @@ $ universal-silabs-flasher \
 ```
 
 ### Home Assistant Connect ZBT-2
-The Home Assistant Connect ZBT-2 will be rebooted into its bootloader from the running application
+The Home Assistant Connect ZBT-2 can use the built-in `zbt2` profile:
 
 ```bash
 $ universal-silabs-flasher \
     --device /dev/ttyACM0 \
     flash \
+    --profile zbt2 \
     --firmware zbt2_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ options:
                          separating them with a comma. Valid values: yellow, ihost, slzb07, rts_dtr, baudrate
 ```
 
-For `flash`, you can also pass `--profile {zbt2}` to use a predefined device profile.
+For `flash`, you can also pass `--profile` to use a predefined device profile.
 `--profile` cannot be combined with `--probe-methods` or `--bootloader-reset`.
 
 ## Flashing firmware

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,12 @@ split-on-trailing-comma = false
 
 [tool.coverage.run]
 source = ["universal_silabs_flasher"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "raise NotImplementedError()",
+]

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -12,7 +12,7 @@ from universal_silabs_flasher.const import (
     ResetTarget,
 )
 from universal_silabs_flasher.flash import main
-from universal_silabs_flasher.flasher import Flasher
+from universal_silabs_flasher.flasher import BaseFlasher, ZBT2Flasher
 
 
 @dataclass
@@ -20,7 +20,7 @@ class Result:
     exit_code: str | int
     output: str
     stderr: str
-    flasher: Flasher
+    flasher: BaseFlasher | None
 
 
 async def invoke_main(argv: list[str]) -> Result:
@@ -31,7 +31,7 @@ async def invoke_main(argv: list[str]) -> Result:
     exit_code: str | int = 0
     captured_flasher = None
 
-    original_init = Flasher.__init__
+    original_init = BaseFlasher.__init__
 
     def capture_init(self, **kwargs):
         nonlocal captured_flasher
@@ -44,11 +44,13 @@ async def invoke_main(argv: list[str]) -> Result:
 
     try:
         with (
-            patch("universal_silabs_flasher.flasher.Flasher.__init__", capture_init),
+            patch(
+                "universal_silabs_flasher.flasher.BaseFlasher.__init__", capture_init
+            ),
             patch("sys.stdout", stdout),
             patch("sys.stderr", stderr),
             patch(
-                "universal_silabs_flasher.flasher.Flasher.probe_app_type",
+                "universal_silabs_flasher.flasher.BaseFlasher.probe_app_type",
                 mock_probe_app_type,
             ),
             patch(
@@ -56,11 +58,11 @@ async def invoke_main(argv: list[str]) -> Result:
                 new_callable=AsyncMock,
             ),
             patch(
-                "universal_silabs_flasher.flasher.Flasher.enter_bootloader",
+                "universal_silabs_flasher.flasher.BaseFlasher.enter_bootloader",
                 new_callable=AsyncMock,
             ),
             patch(
-                "universal_silabs_flasher.flasher.Flasher.flash_firmware",
+                "universal_silabs_flasher.flasher.BaseFlasher.flash_firmware",
                 new_callable=AsyncMock,
             ),
         ):
@@ -181,6 +183,7 @@ async def test_probe_command_argument_parsing(args, expected_device):
     result = await invoke_main(args)
 
     assert result.exit_code == 0
+    assert result.flasher is not None
     assert result.flasher._device == expected_device
 
 
@@ -241,6 +244,23 @@ async def test_dump_gbl_metadata_command():
 
     assert result.exit_code == 0
     assert '{"' in result.output or result.output.strip().endswith("null")
+
+
+async def test_flash_profile_uses_registered_flasher():
+    result = await invoke_main(
+        [
+            "--device",
+            "/dev/ttyUSB0",
+            "flash",
+            "--profile",
+            "zbt2",
+            "--firmware",
+            "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert isinstance(result.flasher, ZBT2Flasher)
 
 
 @pytest.mark.parametrize(
@@ -307,6 +327,34 @@ async def test_dump_gbl_metadata_command():
                 "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
             ],
             "error",
+        ),
+        (
+            [
+                "--device",
+                "/dev/ttyUSB0",
+                "--probe-methods",
+                "ezsp:115200",
+                "flash",
+                "--profile",
+                "zbt2",
+                "--firmware",
+                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
+            ],
+            "--profile cannot be used",
+        ),
+        (
+            [
+                "--device",
+                "/dev/ttyUSB0",
+                "--bootloader-reset",
+                "rts_dtr",
+                "flash",
+                "--profile",
+                "zbt2",
+                "--firmware",
+                "tests/firmwares/skyconnect_zigbee_ncp_7.4.4.0.gbl",
+            ],
+            "--profile cannot be used",
         ),
     ],
 )

--- a/tests/test_flash_cli.py
+++ b/tests/test_flash_cli.py
@@ -12,7 +12,7 @@ from universal_silabs_flasher.const import (
     ResetTarget,
 )
 from universal_silabs_flasher.flash import main
-from universal_silabs_flasher.flasher import BaseFlasher, ZBT2Flasher
+from universal_silabs_flasher.flasher import BaseFlasher, Zbt2Flasher
 
 
 @dataclass
@@ -260,7 +260,7 @@ async def test_flash_profile_uses_registered_flasher():
     )
 
     assert result.exit_code == 0
-    assert isinstance(result.flasher, ZBT2Flasher)
+    assert isinstance(result.flasher, Zbt2Flasher)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -7,13 +7,15 @@ import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
 from universal_silabs_flasher.const import ApplicationType, ResetTarget
-from universal_silabs_flasher.flasher import Flasher, ProbeResult, ZBT2Flasher
+from universal_silabs_flasher.flasher import Flasher, ProbeResult, Zbt2Flasher
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
 
 @pytest.fixture(autouse=True)
 def reduce_timeouts() -> Generator[None, None, None]:
-    with patch("universal_silabs_flasher.flasher.BOOTLOADER_LAUNCH_DELAY", 0.05):
+    with patch(
+        "universal_silabs_flasher.flasher.BaseFlasher._bootloader_launch_delay", 0.05
+    ):
         yield
 
 
@@ -88,7 +90,8 @@ async def test_trigger_bootloader_reset_first_probe_succeeds():
     )
 
     with (
-        patch.object(flasher, "trigger_bootloader") as mock_trigger,
+        patch.object(flasher, "_trigger_baudrate_reset") as mock_trigger_baudrate,
+        patch.object(flasher, "_trigger_gpio_reset") as mock_trigger_gpio,
         patch.object(
             flasher,
             "probe_gecko_bootloader",
@@ -106,10 +109,8 @@ async def test_trigger_bootloader_reset_first_probe_succeeds():
     assert result.baudrate == 115200
 
     # All reset targets are triggered upfront
-    assert mock_trigger.mock_calls == [
-        call(ResetTarget.RTS_DTR),
-        call(ResetTarget.BAUDRATE),
-    ]
+    assert len(mock_trigger_baudrate.mock_calls) == 1
+    assert len(mock_trigger_gpio.mock_calls) == 1
     # Only one probe attempt since the first one succeeds
     assert mock_probe.mock_calls == [call(run_firmware=False, baudrate=115200)]
 
@@ -121,7 +122,8 @@ async def test_trigger_bootloader_reset_all_probes_fail():
     )
 
     with (
-        patch.object(flasher, "trigger_bootloader") as mock_trigger,
+        patch.object(flasher, "_trigger_baudrate_reset") as mock_trigger_baudrate,
+        patch.object(flasher, "_trigger_gpio_reset") as mock_trigger_gpio,
         patch.object(
             flasher,
             "probe_gecko_bootloader",
@@ -133,10 +135,8 @@ async def test_trigger_bootloader_reset_all_probes_fail():
     assert result is None
 
     # All reset targets are triggered upfront
-    assert mock_trigger.mock_calls == [
-        call(ResetTarget.RTS_DTR),
-        call(ResetTarget.BAUDRATE),
-    ]
+    assert len(mock_trigger_baudrate.mock_calls) == 1
+    assert len(mock_trigger_gpio.mock_calls) == 1
     # One probe attempt at the only bootloader baudrate
     assert mock_probe.mock_calls == [
         call(run_firmware=False, baudrate=115200),
@@ -178,7 +178,7 @@ async def test_probe_app_type_fallback_to_bootloader() -> None:
 
 
 async def test_device_specific_probe_app_type_does_not_require_reset_targets() -> None:
-    flasher = ZBT2Flasher(device="/dev/ttyMOCK")
+    flasher = Zbt2Flasher(device="/dev/ttyMOCK")
 
     bootloader_result = ProbeResult(
         version=Version("1.0.0"),

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -1,13 +1,25 @@
 import asyncio
 from collections.abc import Generator
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
-from universal_silabs_flasher.const import ApplicationType, ResetTarget
-from universal_silabs_flasher.flasher import Flasher, ProbeResult, Zbt2Flasher
+from universal_silabs_flasher.const import (
+    ApplicationType,
+    BaudrateResetConfig,
+    GpioPattern,
+    GpioResetConfig,
+    ResetTarget,
+)
+from universal_silabs_flasher.flasher import (
+    Flasher,
+    ProbeResult,
+    YellowFlasher,
+    Zbt1Flasher,
+    Zbt2Flasher,
+)
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
 
@@ -201,3 +213,179 @@ async def test_device_specific_probe_app_type_does_not_require_reset_targets() -
         call(run_firmware=True),
         call(run_firmware=False),
     ]
+
+
+async def test_flasher_init_string_bootloader_reset():
+    flasher = Flasher(device="/dev/ttyMOCK", bootloader_reset="yellow")
+
+    assert flasher._reset_targets == [ResetTarget.YELLOW]
+
+
+async def test_trigger_gpio_reset_cp210x():
+    flasher = Flasher(device="/dev/ttyMOCK")
+
+    config = GpioResetConfig(
+        chip=None,
+        chip_type="cp210x",
+        pattern=[GpioPattern(pins={4: True, 5: True}, delay_after=0.1)],
+    )
+
+    with (
+        patch(
+            "universal_silabs_flasher.flasher.find_gpiochip_by_label",
+            return_value="/dev/gpiochip_mock",
+        ) as mock_find,
+        patch("universal_silabs_flasher.flasher.send_gpio_pattern") as mock_send,
+    ):
+        await flasher._trigger_gpio_reset(config)
+
+    assert mock_find.mock_calls == [call("cp210x")]
+    assert mock_send.mock_calls == [call("/dev/gpiochip_mock", config.pattern)]
+
+
+async def test_trigger_gpio_reset_uart():
+    flasher = Flasher(device="/dev/ttyMOCK")
+
+    config = GpioResetConfig(
+        chip=None,
+        chip_type="uart",
+        pattern=[
+            GpioPattern(pins={"dtr": False, "rts": True}, delay_after=0.0),
+            GpioPattern(pins={"dtr": True, "rts": False}, delay_after=0.0),
+        ],
+    )
+
+    with patch(
+        "universal_silabs_flasher.flasher.connect_protocol"
+    ) as mock_connect_protocol:
+        mock_uart = mock_connect_protocol.return_value.__aenter__.return_value
+        mock_uart.set_signals = AsyncMock()
+        await flasher._trigger_gpio_reset(config)
+
+    assert mock_connect_protocol.mock_calls[0] == call(
+        "/dev/ttyMOCK", 115200, FlowControlSerialProtocol
+    )
+    assert mock_uart.set_signals.mock_calls == [
+        call(dtr=False, rts=True),
+        call(dtr=True, rts=False),
+    ]
+
+
+async def test_reset_config_flasher_trigger_bootloader_reset():
+    flasher = YellowFlasher(device="/dev/ttyMOCK", probe_methods=[])
+
+    assert flasher._can_trigger_bootloader_reset() is True
+
+    probe_result = ProbeResult(
+        version=Version("1.0.0"), continue_probing=False, baudrate=115200
+    )
+
+    with (
+        patch.object(flasher, "_trigger_gpio_reset") as mock_gpio_reset,
+        patch.object(
+            flasher, "_detect_gecko_bootloader", return_value=probe_result
+        ) as mock_detect,
+    ):
+        result = await flasher.trigger_bootloader_reset(run_firmware=False)
+
+    assert result == probe_result
+    assert len(mock_gpio_reset.mock_calls) == 1
+    assert mock_detect.mock_calls == [call(run_firmware=False)]
+
+
+async def test_zbt1_flasher():
+    flasher = Zbt1Flasher(device="/dev/ttyMOCK", probe_methods=[])
+
+    assert flasher._can_trigger_bootloader_reset() is False
+
+    result = await flasher.trigger_bootloader_reset(run_firmware=False)
+    assert result is None
+
+
+async def test_zbt2_flasher_trigger_bootloader_reset_first_attempt_succeeds():
+    flasher = Zbt2Flasher(device="/dev/ttyMOCK")
+
+    probe_result = ProbeResult(
+        version=Version("1.0.0"), continue_probing=False, baudrate=115200
+    )
+
+    with (
+        patch.object(flasher, "_trigger_baudrate_reset") as mock_baudrate_reset,
+        patch.object(
+            flasher, "_detect_gecko_bootloader", return_value=probe_result
+        ) as mock_detect,
+    ):
+        result = await flasher.trigger_bootloader_reset(run_firmware=False)
+
+    assert result == probe_result
+    assert mock_baudrate_reset.mock_calls == [
+        call(
+            BaudrateResetConfig(
+                baudrates=(150, 300, 1200),
+                delay_after_each=0.1,
+                delay_after_final=0.5,
+                command=b"BZ",
+            )
+        )
+    ]
+    assert mock_detect.mock_calls == [call(run_firmware=False)]
+
+
+async def test_zbt2_flasher_trigger_bootloader_reset_hard_reset_fallback():
+    flasher = Zbt2Flasher(device="/dev/ttyMOCK")
+    flasher._reconnect_timeout = 5
+
+    probe_result = ProbeResult(
+        version=Version("1.0.0"), continue_probing=False, baudrate=115200
+    )
+
+    with (
+        patch.object(
+            flasher,
+            "_trigger_baudrate_reset",
+            side_effect=[
+                # Call 1: BZ (initial) - succeeds
+                None,
+                # Call 2: RE (hard reset) - raises (device disconnects)
+                ConnectionError("device disconnected"),
+                # Call 3: BZ (reconnect attempt 1) - raises (not ready yet)
+                ConnectionError("not ready yet"),
+                # Call 4: BZ (reconnect attempt 2) - succeeds
+                None,
+            ],
+        ) as mock_baudrate_reset,
+        patch.object(
+            flasher,
+            "_detect_gecko_bootloader",
+            side_effect=[None, probe_result],
+        ) as mock_detect,
+    ):
+        result = await flasher.trigger_bootloader_reset(run_firmware=False)
+
+    assert result == probe_result
+    # 4 baudrate reset calls: BZ, RE(fail), BZ(fail), BZ(success)
+    assert len(mock_baudrate_reset.mock_calls) == 4
+    # 2 detect calls: first returns None, second returns result
+    assert len(mock_detect.mock_calls) == 2
+
+
+async def test_enter_bootloader_from_application():
+    flasher = Flasher(device="/dev/ttyMOCK")
+    flasher.app_type = ApplicationType.CPC
+    flasher.app_baudrate = 115200
+
+    probe_result = ProbeResult(
+        version=Version("1.0.0"), continue_probing=False, baudrate=115200
+    )
+
+    with (
+        patch.object(flasher, "trigger_bootloader_reset", return_value=None),
+        patch.object(flasher, "_connect_cpc") as mock_connect_cpc,
+        patch.object(flasher, "_detect_gecko_bootloader", return_value=probe_result),
+    ):
+        mock_cpc = mock_connect_cpc.return_value.__aenter__.return_value
+        mock_cpc.enter_bootloader = AsyncMock()
+        await flasher.enter_bootloader()
+
+    assert flasher.bootloader_baudrate == 115200
+    assert len(mock_cpc.enter_bootloader.mock_calls) == 1

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -7,7 +7,7 @@ import zigpy.types as t
 
 from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
 from universal_silabs_flasher.const import ApplicationType, ResetTarget
-from universal_silabs_flasher.flasher import Flasher, ProbeResult
+from universal_silabs_flasher.flasher import Flasher, ProbeResult, ZBT2Flasher
 from universal_silabs_flasher.gecko_bootloader import GeckoBootloaderProtocol
 
 
@@ -175,3 +175,29 @@ async def test_probe_app_type_fallback_to_bootloader() -> None:
     # trigger_bootloader_reset should be called twice - once at start and once
     # for fallback
     assert mock_trigger_reset.call_count == 2
+
+
+async def test_device_specific_probe_app_type_does_not_require_reset_targets() -> None:
+    flasher = ZBT2Flasher(device="/dev/ttyMOCK")
+
+    bootloader_result = ProbeResult(
+        version=Version("1.0.0"),
+        continue_probing=False,
+        baudrate=115200,
+    )
+
+    with patch.object(
+        flasher,
+        "trigger_bootloader_reset",
+        side_effect=[bootloader_result, bootloader_result],
+    ) as mock_trigger_reset:
+        await flasher.probe_app_type()
+
+    assert flasher.app_type == ApplicationType.GECKO_BOOTLOADER
+    assert flasher.app_version == Version("1.0.0")
+    assert flasher.app_baudrate == 115200
+    assert flasher.bootloader_baudrate == 115200
+    assert mock_trigger_reset.mock_calls == [
+        call(run_firmware=True),
+        call(run_firmware=False),
+    ]

--- a/universal_silabs_flasher/const.py
+++ b/universal_silabs_flasher/const.py
@@ -86,7 +86,7 @@ class BaudrateResetConfig:
 
 
 # fmt: off
-RESET_CONFIGS = {
+RESET_CONFIGS: dict[ResetTarget, GpioResetConfig | BaudrateResetConfig] = {
     ResetTarget.YELLOW: GpioResetConfig(
         chip="/dev/gpiochip0",
         chip_type=None,

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -11,15 +11,9 @@ import tqdm
 import zigpy.ota.validators
 import zigpy.types
 
-from .common import put_first
-from .const import (
-    DEFAULT_PROBE_METHODS,
-    FW_IMAGE_TYPE_TO_APPLICATION_TYPE,
-    ApplicationType,
-    ResetTarget,
-)
+from .const import DEFAULT_PROBE_METHODS, ApplicationType, ResetTarget
 from .firmware import parse_firmware_image
-from .flasher import FLASHERS, Flasher
+from .flasher import DEVICE_SPECIFIC_FLASHERS, Flasher
 from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,7 +148,7 @@ async def main(argv: list[str] | None = None) -> None:
     )
     flash_parser.add_argument(
         "--profile",
-        choices=sorted(FLASHERS),
+        choices=list(reversed(DEVICE_SPECIFIC_FLASHERS)),
         default=argparse.SUPPRESS,
         help=(
             "Use a predefined flashing profile. Cannot be used with"
@@ -187,7 +181,7 @@ async def main(argv: list[str] | None = None) -> None:
                 "--profile cannot be used with " + ", ".join(incompatible_args)
             )
 
-        flasher_cls = FLASHERS[args.profile]
+        flasher_cls = DEVICE_SPECIFIC_FLASHERS[args.profile]
         flasher = flasher_cls(device=getattr(args, "device", None))
     else:
         flasher = Flasher(
@@ -278,18 +272,6 @@ async def _cmd_flash(
         metadata = None
     else:
         _LOGGER.info("Extracted GBL metadata: %s", metadata)
-
-    # Prefer to probe with the current firmware's settings to speed up startup after the
-    # firmware is flashed for the first time
-    if metadata is not None and metadata.fw_type is not None:
-        app_type = FW_IMAGE_TYPE_TO_APPLICATION_TYPE[metadata.fw_type]
-
-        _LOGGER.debug(
-            "Probing app type %s at %s baud first", app_type, metadata.baudrate
-        )
-        flasher._probe_methods = put_first(
-            flasher._probe_methods, [(app_type, metadata.baudrate)]
-        )
 
     try:
         await flasher.probe_app_type()

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -19,7 +19,7 @@ from .const import (
     ResetTarget,
 )
 from .firmware import parse_firmware_image
-from .flasher import Flasher
+from .flasher import FLASHERS, Flasher
 from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
 _LOGGER = logging.getLogger(__name__)
@@ -152,16 +152,20 @@ async def main(argv: list[str] | None = None) -> None:
         type=argparse.FileType("rb"),
         required=True,
     )
+    flash_parser.add_argument(
+        "--profile",
+        choices=sorted(FLASHERS),
+        default=argparse.SUPPRESS,
+        help=(
+            "Use a predefined flashing profile. Cannot be used with"
+            " --probe-methods or --bootloader-reset."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
     coloredlogs.install(
-        fmt=(
-            "%(asctime)s.%(msecs)03d"
-            " %(hostname)s"
-            " %(name)s"
-            " %(levelname)s %(message)s"
-        ),
+        fmt=("%(asctime)s.%(msecs)03d %(hostname)s %(name)s %(levelname)s %(message)s"),
         level=LOG_LEVELS[min(len(LOG_LEVELS) - 1, getattr(args, "verbose", 0))],
     )
 
@@ -169,11 +173,28 @@ async def main(argv: list[str] | None = None) -> None:
     if not hasattr(args, "device") and args.command != "dump-gbl-metadata":
         parser.error("Missing option '--device'")
 
-    flasher = Flasher(
-        device=getattr(args, "device", None),
-        probe_methods=list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS)),
-        bootloader_reset=tuple(getattr(args, "bootloader_reset", [])),
-    )
+    if args.command == "flash" and hasattr(args, "profile"):
+        incompatible_args = []
+
+        if hasattr(args, "probe_methods"):
+            incompatible_args.append("--probe-methods")
+
+        if hasattr(args, "bootloader_reset"):
+            incompatible_args.append("--bootloader-reset")
+
+        if incompatible_args:
+            parser.error(
+                "--profile cannot be used with " + ", ".join(incompatible_args)
+            )
+
+        flasher_cls = FLASHERS[args.profile]
+        flasher = flasher_cls(device=getattr(args, "device", None))
+    else:
+        flasher = Flasher(
+            device=getattr(args, "device", None),
+            probe_methods=list(getattr(args, "probe_methods", DEFAULT_PROBE_METHODS)),
+            bootloader_reset=tuple(getattr(args, "bootloader_reset", [])),
+        )
 
     if args.command == "dump-gbl-metadata":
         await _cmd_dump_gbl_metadata(args)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -210,7 +210,7 @@ class BaseFlasher:
             _LOGGER.warning(
                 "When using %s bootloader reset ensure no other CP2102 USB serial"
                 " devices are connected.",
-                config.target.value,
+                config.chip_type,
             )
 
             chip = await find_gpiochip_by_label(config.chip_type)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -40,6 +40,7 @@ from .spinel import SpinelProtocol
 from .zwave import ZWaveProtocol
 
 _LOGGER = logging.getLogger(__name__)
+T = typing.TypeVar("T", bound="type[DeviceSpecificFlasher]")
 
 BOOTLOADER_LAUNCH_DELAY = 3
 
@@ -53,6 +54,14 @@ class ProbeResult:
     version: Version | None
     continue_probing: bool
     baudrate: int
+
+
+FLASHERS: dict[str, type[BaseFlasher]] = {}
+
+
+def register_flasher(cls: T) -> T:
+    FLASHERS[cls.name] = cls
+    return cls
 
 
 class BaseFlasher:
@@ -500,7 +509,12 @@ class Flasher(BaseFlasher):
         return True
 
 
-class ZBT2Flasher(BaseFlasher):
+class DeviceSpecificFlasher(BaseFlasher):
+    pass
+
+
+@register_flasher
+class ZBT2Flasher(DeviceSpecificFlasher):
     name = "zbt2"
     _default_probe_methods = (
         (ApplicationType.GECKO_BOOTLOADER, 115200),

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -42,8 +42,6 @@ from .zwave import ZWaveProtocol
 _LOGGER = logging.getLogger(__name__)
 T = typing.TypeVar("T", bound="type[DeviceSpecificFlasher]")
 
-BOOTLOADER_LAUNCH_DELAY = 3
-
 
 class FailedToEnterBootloaderError(Exception):
     """Failed to enter the bootloader."""
@@ -65,10 +63,11 @@ def register_flasher(cls: T) -> T:
 
 
 class BaseFlasher:
-    name: str
     _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]] = (
         DEFAULT_PROBE_METHODS
     )
+
+    _bootloader_launch_delay: float = 3
 
     def __init__(
         self,
@@ -367,7 +366,7 @@ class BaseFlasher:
             raise RuntimeError(f"Invalid application type: {self.app_type}")
 
         if self.app_type is not ApplicationType.GECKO_BOOTLOADER:
-            await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
+            await asyncio.sleep(self._bootloader_launch_delay)
 
         # Verify the bootloader has launched
         bootloader_probe = await self._detect_gecko_bootloader(run_firmware=False)
@@ -403,8 +402,6 @@ class BaseFlasher:
 
 class Flasher(BaseFlasher):
     """Backwards compatible generic flasher."""
-
-    name = "flasher"
 
     def __init__(
         self,
@@ -479,7 +476,7 @@ class Flasher(BaseFlasher):
             _LOGGER.info(f"Triggering {target.value} bootloader")
             await self.trigger_bootloader(target)
 
-        await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
+        await asyncio.sleep(self._bootloader_launch_delay)
 
         return await self._detect_gecko_bootloader(run_firmware=run_firmware)
 
@@ -517,7 +514,7 @@ class Flasher(BaseFlasher):
 
 
 class DeviceSpecificFlasher(BaseFlasher):
-    pass
+    name: str
 
 
 @register_flasher
@@ -530,15 +527,18 @@ class ZBT2Flasher(DeviceSpecificFlasher):
         (ApplicationType.ROUTER, 115200),
     )
 
-    async def _send_esp_command(self, command: str) -> None:
-        for baudrate in [150, 300, 1200]:
+    _esp32_trigger_baudrates = (150, 300, 1200)
+    _reconnect_timeout: float = 10
+
+    async def _send_esp32_command(self, command: str) -> None:
+        for index, baudrate in enumerate(self._esp32_trigger_baudrates):
             async with connect_protocol(
                 self._device, baudrate, FlowControlSerialProtocol
             ) as uart:
                 await asyncio.sleep(0.1)
 
                 # Write command on the last baudrate if specified
-                if baudrate == 1200:
+                if index == len(self._esp32_trigger_baudrates) - 1:
                     _LOGGER.debug("Sending command to ZBT-2 ESP: %r", command)
                     uart._transport.write(command.encode("ascii"))
                     await asyncio.sleep(0.5)
@@ -547,7 +547,7 @@ class ZBT2Flasher(DeviceSpecificFlasher):
         self, *, run_firmware: bool
     ) -> ProbeResult | None:
         # Try to trigger the bootloader nicely
-        await self._send_esp_command("BZ")
+        await self._send_esp32_command("BZ")
 
         bootloader_probe = await self._detect_gecko_bootloader(
             run_firmware=run_firmware
@@ -558,20 +558,22 @@ class ZBT2Flasher(DeviceSpecificFlasher):
         # We failed and the ESP firmware's UART thread is stuck. Hard reset...
         _LOGGER.debug("Failed to trigger bootloader, trying hard reset")
         try:
-            await self._send_esp_command("RE")
+            await self._send_esp32_command("RE")
         except Exception as exc:
             _LOGGER.debug("Expected failure when sending reset command: %r", exc)
 
         # Wait for a while for the stick to come back
-        async with asyncio_timeout(10):
+        async with asyncio_timeout(self._reconnect_timeout):
             while True:
                 try:
-                    await self._send_esp_command("BZ")
+                    await self._send_esp32_command("BZ")
                     break
                 except Exception as exc:
                     await asyncio.sleep(0.5)
                     _LOGGER.debug(
                         "Device unavailable, waiting for it to reappear: %r", exc
                     )
+
+        await asyncio.sleep(self._bootloader_launch_delay)
 
         return await self._detect_gecko_bootloader(run_firmware=run_firmware)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -56,29 +56,31 @@ class ProbeResult:
 
 
 class BaseFlasher:
+    name: str
+    _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]] = (
+        DEFAULT_PROBE_METHODS
+    )
+
     def __init__(
         self,
         *,
         device: str,
-        probe_methods: typing.Sequence[
-            tuple[ApplicationType, int]
-        ] = DEFAULT_PROBE_METHODS,
+        probe_methods: typing.Sequence[tuple[ApplicationType, int]] | None = None,
         # To restore flasher "state", we can pass these to the constructor
         app_type: ApplicationType | None = None,
         app_version: Version | None = None,
         app_baudrate: int | None = None,
         bootloader_baudrate: int | None = None,
     ):
-        self._probe_methods = probe_methods
+        self._probe_methods = (
+            probe_methods if probe_methods is not None else self._default_probe_methods
+        )
         self._device = device
 
         self.app_type = app_type
         self.app_version = app_version
         self.app_baudrate = app_baudrate
         self.bootloader_baudrate = bootloader_baudrate
-
-    async def trigger_bootloader(self, target: ResetTarget) -> None:
-        raise NotImplementedError
 
     def _connect_gecko_bootloader(self, baudrate: int):
         return connect_protocol(self._device, baudrate, GeckoBootloaderProtocol)
@@ -389,6 +391,8 @@ class BaseFlasher:
 class Flasher(BaseFlasher):
     """Backwards compatible generic flasher."""
 
+    name = "flasher"
+
     def __init__(
         self,
         *,
@@ -494,3 +498,44 @@ class Flasher(BaseFlasher):
             _LOGGER.info("Wrote new device IEEE: %s", new_ieee)
 
         return True
+
+
+class ZBT2Flasher(BaseFlasher):
+    name = "zbt2"
+    _default_probe_methods = (
+        (ApplicationType.GECKO_BOOTLOADER, 115200),
+        (ApplicationType.EZSP, 460800),
+        (ApplicationType.SPINEL, 460800),
+        (ApplicationType.ROUTER, 115200),
+    )
+
+    async def _send_esp_command(self, command: str) -> None:
+        for baudrate in [150, 300, 1200]:
+            async with connect_protocol(
+                self._device, baudrate, FlowControlSerialProtocol
+            ) as uart:
+                await asyncio.sleep(0.1)
+
+                # Write command on the last baudrate if specified
+                if baudrate == 1200:
+                    uart._transport.write(command.encode("ascii"))
+                    await asyncio.sleep(0.5)
+
+    async def trigger_bootloader_reset(
+        self, *, run_firmware: bool
+    ) -> ProbeResult | None:
+        # Try to trigger the bootloader nicely
+        await self._send_esp_command("BZ")
+
+        bootloader_probe = await self._detect_gecko_bootloader(
+            run_firmware=run_firmware
+        )
+        if bootloader_probe is not None:
+            return bootloader_probe
+
+        # We failed and the ESP firmware's UART thread is stuck. Hard reset...
+        _LOGGER.debug("Failed to trigger bootloader, trying hard reset")
+        await self._send_esp_command("RE")
+        await self._send_esp_command("BZ")
+
+        return await self._detect_gecko_bootloader(run_firmware=run_firmware)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -539,6 +539,7 @@ class ZBT2Flasher(DeviceSpecificFlasher):
 
                 # Write command on the last baudrate if specified
                 if baudrate == 1200:
+                    _LOGGER.debug("Sending command to ZBT-2 ESP: %r", command)
                     uart._transport.write(command.encode("ascii"))
                     await asyncio.sleep(0.5)
 
@@ -556,7 +557,21 @@ class ZBT2Flasher(DeviceSpecificFlasher):
 
         # We failed and the ESP firmware's UART thread is stuck. Hard reset...
         _LOGGER.debug("Failed to trigger bootloader, trying hard reset")
-        await self._send_esp_command("RE")
-        await self._send_esp_command("BZ")
+        try:
+            await self._send_esp_command("RE")
+        except Exception as exc:
+            _LOGGER.debug("Expected failure when sending reset command: %r", exc)
+
+        # Wait for a while for the stick to come back
+        async with asyncio_timeout(10):
+            while True:
+                try:
+                    await self._send_esp_command("BZ")
+                    break
+                except Exception as exc:
+                    await asyncio.sleep(0.5)
+                    _LOGGER.debug(
+                        "Device unavailable, waiting for it to reappear: %r", exc
+                    )
 
         return await self._detect_gecko_bootloader(run_firmware=run_firmware)

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -190,6 +190,9 @@ class BaseFlasher:
 
         raise NotImplementedError
 
+    def _can_trigger_bootloader_reset(self) -> bool:
+        return True
+
     async def _detect_gecko_bootloader(
         self, *, run_firmware: bool
     ) -> ProbeResult | None:
@@ -235,7 +238,8 @@ class BaseFlasher:
             m == ApplicationType.GECKO_BOOTLOADER for m, _ in probe_methods
         )
 
-        run_firmware = self._reset_targets and not only_probe_bootloader
+        can_trigger_bootloader_reset = self._can_trigger_bootloader_reset()
+        run_firmware = can_trigger_bootloader_reset and not only_probe_bootloader
 
         probe_funcs = {
             ApplicationType.GECKO_BOOTLOADER: (
@@ -294,7 +298,7 @@ class BaseFlasher:
                 break
 
         if self.app_type is None:
-            if not bootloader_probe or not self._reset_targets:
+            if not bootloader_probe or not can_trigger_bootloader_reset:
                 raise RuntimeError("Failed to probe running application type")
 
             # We have no valid application image but can still re-enter the
@@ -416,6 +420,9 @@ class Flasher(BaseFlasher):
         self._reset_targets: list[ResetTarget] = [
             ResetTarget(target) for target in bootloader_reset if target
         ]
+
+    def _can_trigger_bootloader_reset(self) -> bool:
+        return bool(self._reset_targets)
 
     async def trigger_bootloader(self, target: ResetTarget) -> None:
         config = RESET_CONFIGS[target]

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -560,7 +560,7 @@ class YellowFlasher(ResetConfigFlasher):
 
 
 @register_flasher
-class ZBT1Flasher(ResetConfigFlasher):
+class Zbt1Flasher(ResetConfigFlasher):
     name = "zbt1"
 
     def _can_trigger_bootloader_reset(self) -> bool:
@@ -574,7 +574,7 @@ class ZBT1Flasher(ResetConfigFlasher):
 
 
 @register_flasher
-class ZBT2Flasher(DeviceSpecificFlasher):
+class Zbt2Flasher(DeviceSpecificFlasher):
     name = "zbt2"
     _default_probe_methods = (
         (ApplicationType.GECKO_BOOTLOADER, 115200),

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -54,11 +54,11 @@ class ProbeResult:
     baudrate: int
 
 
-FLASHERS: dict[str, type[BaseFlasher]] = {}
+DEVICE_SPECIFIC_FLASHERS: dict[str, type[BaseFlasher]] = {}
 
 
 def register_flasher(cls: T) -> T:
-    FLASHERS[cls.name] = cls
+    DEVICE_SPECIFIC_FLASHERS[cls.name] = cls
     return cls
 
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -63,10 +63,7 @@ def register_flasher(cls: T) -> T:
 
 
 class BaseFlasher:
-    _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]] = (
-        DEFAULT_PROBE_METHODS
-    )
-
+    _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]]
     _bootloader_launch_delay: float = 3
 
     def __init__(
@@ -191,6 +188,43 @@ class BaseFlasher:
 
     def _can_trigger_bootloader_reset(self) -> bool:
         return True
+
+    async def _trigger_baudrate_reset(self, config: BaudrateResetConfig) -> None:
+        # Baudrate command mode uses a pattern of baudrates to enter a command mode
+        for baudrate in config.baudrates:
+            async with connect_protocol(
+                self._device, baudrate, FlowControlSerialProtocol
+            ) as uart:
+                await asyncio.sleep(config.delay_after_each)
+
+                # Write command on the last baudrate if specified
+                if baudrate == config.baudrates[-1] and config.command:
+                    uart._transport.write(config.command)
+
+        await asyncio.sleep(config.delay_after_final)
+
+    async def _trigger_gpio_reset(self, config: GpioResetConfig) -> None:
+        chip = config.chip
+
+        if config.chip_type == "cp210x":
+            _LOGGER.warning(
+                "When using %s bootloader reset ensure no other CP2102 USB serial"
+                " devices are connected.",
+                config.target.value,
+            )
+
+            chip = await find_gpiochip_by_label(config.chip_type)
+
+        if config.chip_type == "uart":
+            # The baudrate isn't necessary, since we're just using flow control pins
+            async with connect_protocol(
+                self._device, 115200, FlowControlSerialProtocol
+            ) as uart:
+                for pattern in config.pattern:
+                    await uart.set_signals(**pattern.pins)
+                    await asyncio.sleep(pattern.delay_after)
+        else:
+            await send_gpio_pattern(chip, config.pattern)
 
     async def _detect_gecko_bootloader(
         self, *, run_firmware: bool
@@ -403,6 +437,8 @@ class BaseFlasher:
 class Flasher(BaseFlasher):
     """Backwards compatible generic flasher."""
 
+    _default_probe_methods = DEFAULT_PROBE_METHODS
+
     def __init__(
         self,
         *,
@@ -421,47 +457,6 @@ class Flasher(BaseFlasher):
     def _can_trigger_bootloader_reset(self) -> bool:
         return bool(self._reset_targets)
 
-    async def trigger_bootloader(self, target: ResetTarget) -> None:
-        config = RESET_CONFIGS[target]
-
-        if isinstance(config, BaudrateResetConfig):
-            # Baudrate command mode uses a pattern of baudrates to enter a command mode
-            for baudrate in config.baudrates:
-                async with connect_protocol(
-                    self._device, baudrate, FlowControlSerialProtocol
-                ) as uart:
-                    await asyncio.sleep(config.delay_after_each)
-
-                    # Write command on the last baudrate if specified
-                    if baudrate == config.baudrates[-1] and config.command:
-                        uart._transport.write(config.command)
-
-            await asyncio.sleep(config.delay_after_final)
-        elif isinstance(config, GpioResetConfig):
-            chip = config.chip
-
-            if config.chip_type == "cp210x":
-                _LOGGER.warning(
-                    "When using %s bootloader reset ensure no other CP2102 USB serial"
-                    " devices are connected.",
-                    target.value,
-                )
-
-                chip = await find_gpiochip_by_label(config.chip_type)
-
-            if config.chip_type == "uart":
-                # The baudrate isn't necessary, since we're just using flow control pins
-                async with connect_protocol(
-                    self._device, 115200, FlowControlSerialProtocol
-                ) as uart:
-                    for pattern in config.pattern:
-                        await uart.set_signals(**pattern.pins)
-                        await asyncio.sleep(pattern.delay_after)
-            else:
-                await send_gpio_pattern(chip, config.pattern)
-        else:
-            raise TypeError(f"Invalid reset configuration for {target!r}")
-
     async def trigger_bootloader_reset(
         self, *, run_firmware: bool
     ) -> ProbeResult | None:
@@ -474,7 +469,12 @@ class Flasher(BaseFlasher):
         # We don't really care which method works, just try them all at once
         for target in self._reset_targets:
             _LOGGER.info(f"Triggering {target.value} bootloader")
-            await self.trigger_bootloader(target)
+            config = RESET_CONFIGS[target]
+
+            if isinstance(config, BaudrateResetConfig):
+                await self._trigger_baudrate_reset(config)
+            elif isinstance(config, GpioResetConfig):
+                await self._trigger_gpio_reset(config)
 
         await asyncio.sleep(self._bootloader_launch_delay)
 
@@ -517,6 +517,62 @@ class DeviceSpecificFlasher(BaseFlasher):
     name: str
 
 
+class ResetConfigFlasher(DeviceSpecificFlasher):
+    """Flasher for a device with an existing GPIO or baudrate reset method."""
+
+    _reset_config: GpioResetConfig | BaudrateResetConfig
+
+    def _can_trigger_bootloader_reset(self) -> bool:
+        return True
+
+    async def trigger_bootloader_reset(
+        self, *, run_firmware: bool
+    ) -> ProbeResult | None:
+        """Reset into the bootloader."""
+        await self._trigger_gpio_reset(self._reset_config)
+        await asyncio.sleep(self._bootloader_launch_delay)
+
+        return await self._detect_gecko_bootloader(run_firmware=run_firmware)
+
+
+@register_flasher
+class IhostFlasher(ResetConfigFlasher):
+    name = "ihost"
+    _reset_config = RESET_CONFIGS[ResetTarget.IHOST]
+
+
+@register_flasher
+class Slzb07Flasher(ResetConfigFlasher):
+    name = "slzb07"
+    _reset_config = RESET_CONFIGS[ResetTarget.SLZB07]
+
+
+@register_flasher
+class GenericRtsDtrFlasher(ResetConfigFlasher):
+    name = "rts_dtr"
+    _reset_config = RESET_CONFIGS[ResetTarget.RTS_DTR]
+
+
+@register_flasher
+class YellowFlasher(ResetConfigFlasher):
+    name = "yellow"
+    _reset_config = RESET_CONFIGS[ResetTarget.YELLOW]
+
+
+@register_flasher
+class ZBT1Flasher(ResetConfigFlasher):
+    name = "zbt1"
+
+    def _can_trigger_bootloader_reset(self) -> bool:
+        return False
+
+    async def trigger_bootloader_reset(
+        self, *, run_firmware: bool
+    ) -> ProbeResult | None:
+        """Reset into the bootloader."""
+        return None
+
+
 @register_flasher
 class ZBT2Flasher(DeviceSpecificFlasher):
     name = "zbt2"
@@ -531,17 +587,14 @@ class ZBT2Flasher(DeviceSpecificFlasher):
     _reconnect_timeout: float = 10
 
     async def _send_esp32_command(self, command: str) -> None:
-        for index, baudrate in enumerate(self._esp32_trigger_baudrates):
-            async with connect_protocol(
-                self._device, baudrate, FlowControlSerialProtocol
-            ) as uart:
-                await asyncio.sleep(0.1)
-
-                # Write command on the last baudrate if specified
-                if index == len(self._esp32_trigger_baudrates) - 1:
-                    _LOGGER.debug("Sending command to ZBT-2 ESP: %r", command)
-                    uart._transport.write(command.encode("ascii"))
-                    await asyncio.sleep(0.5)
+        await self._trigger_baudrate_reset(
+            BaudrateResetConfig(
+                baudrates=self._esp32_trigger_baudrates,
+                delay_after_each=0.1,
+                delay_after_final=0.5,
+                command=command.encode("ascii"),
+            )
+        )
 
     async def trigger_bootloader_reset(
         self, *, run_firmware: bool

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -55,15 +55,14 @@ class ProbeResult:
     baudrate: int
 
 
-class Flasher:
+class BaseFlasher:
     def __init__(
         self,
         *,
+        device: str,
         probe_methods: typing.Sequence[
             tuple[ApplicationType, int]
         ] = DEFAULT_PROBE_METHODS,
-        device: str,
-        bootloader_reset: str | tuple[ResetTarget, ...] = (),
         # To restore flasher "state", we can pass these to the constructor
         app_type: ApplicationType | None = None,
         app_version: Version | None = None,
@@ -78,53 +77,8 @@ class Flasher:
         self.app_baudrate = app_baudrate
         self.bootloader_baudrate = bootloader_baudrate
 
-        if isinstance(bootloader_reset, str):
-            bootloader_reset = (ResetTarget(bootloader_reset),)
-
-        self._reset_targets: list[ResetTarget] = [
-            ResetTarget(target) for target in bootloader_reset if target
-        ]
-
     async def trigger_bootloader(self, target: ResetTarget) -> None:
-        config = RESET_CONFIGS[target]
-
-        if isinstance(config, BaudrateResetConfig):
-            # Baudrate command mode uses a pattern of baudrates to enter a command mode
-            for baudrate in config.baudrates:
-                async with connect_protocol(
-                    self._device, baudrate, FlowControlSerialProtocol
-                ) as uart:
-                    await asyncio.sleep(config.delay_after_each)
-
-                    # Write command on the last baudrate if specified
-                    if baudrate == config.baudrates[-1] and config.command:
-                        uart._transport.write(config.command)
-
-            await asyncio.sleep(config.delay_after_final)
-        elif isinstance(config, GpioResetConfig):
-            chip = config.chip
-
-            if config.chip_type == "cp210x":
-                _LOGGER.warning(
-                    "When using %s bootloader reset ensure no other CP2102 USB serial"
-                    " devices are connected.",
-                    target.value,
-                )
-
-                chip = await find_gpiochip_by_label(config.chip_type)
-
-            if config.chip_type == "uart":
-                # The baudrate isn't necessary, since we're just using flow control pins
-                async with connect_protocol(
-                    self._device, 115200, FlowControlSerialProtocol
-                ) as uart:
-                    for pattern in config.pattern:
-                        await uart.set_signals(**pattern.pins)
-                        await asyncio.sleep(pattern.delay_after)
-            else:
-                await send_gpio_pattern(chip, config.pattern)
-        else:
-            raise TypeError(f"Invalid reset configuration for {target!r}")
+        raise NotImplementedError
 
     def _connect_gecko_bootloader(self, baudrate: int):
         return connect_protocol(self._device, baudrate, GeckoBootloaderProtocol)
@@ -223,18 +177,7 @@ class Flasher:
     ) -> ProbeResult | None:
         """Reset into the bootloader by trying the probing methods, one by one."""
 
-        # If we have no way to enter the bootloader, don't try
-        if not self._reset_targets:
-            return None
-
-        # We don't really care which method works, just try them all at once
-        for target in self._reset_targets:
-            _LOGGER.info(f"Triggering {target.value} bootloader")
-            await self.trigger_bootloader(target)
-
-        await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
-
-        return await self._detect_gecko_bootloader(run_firmware=run_firmware)
+        raise NotImplementedError
 
     async def _detect_gecko_bootloader(
         self, *, run_firmware: bool
@@ -441,6 +384,84 @@ class Flasher:
 
             if run_firmware:
                 await gecko.run_firmware()
+
+
+class Flasher(BaseFlasher):
+    """Backwards compatible generic flasher."""
+
+    def __init__(
+        self,
+        *,
+        bootloader_reset: str | tuple[ResetTarget, ...] = (),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if isinstance(bootloader_reset, str):
+            bootloader_reset = (ResetTarget(bootloader_reset),)
+
+        self._reset_targets: list[ResetTarget] = [
+            ResetTarget(target) for target in bootloader_reset if target
+        ]
+
+    async def trigger_bootloader(self, target: ResetTarget) -> None:
+        config = RESET_CONFIGS[target]
+
+        if isinstance(config, BaudrateResetConfig):
+            # Baudrate command mode uses a pattern of baudrates to enter a command mode
+            for baudrate in config.baudrates:
+                async with connect_protocol(
+                    self._device, baudrate, FlowControlSerialProtocol
+                ) as uart:
+                    await asyncio.sleep(config.delay_after_each)
+
+                    # Write command on the last baudrate if specified
+                    if baudrate == config.baudrates[-1] and config.command:
+                        uart._transport.write(config.command)
+
+            await asyncio.sleep(config.delay_after_final)
+        elif isinstance(config, GpioResetConfig):
+            chip = config.chip
+
+            if config.chip_type == "cp210x":
+                _LOGGER.warning(
+                    "When using %s bootloader reset ensure no other CP2102 USB serial"
+                    " devices are connected.",
+                    target.value,
+                )
+
+                chip = await find_gpiochip_by_label(config.chip_type)
+
+            if config.chip_type == "uart":
+                # The baudrate isn't necessary, since we're just using flow control pins
+                async with connect_protocol(
+                    self._device, 115200, FlowControlSerialProtocol
+                ) as uart:
+                    for pattern in config.pattern:
+                        await uart.set_signals(**pattern.pins)
+                        await asyncio.sleep(pattern.delay_after)
+            else:
+                await send_gpio_pattern(chip, config.pattern)
+        else:
+            raise TypeError(f"Invalid reset configuration for {target!r}")
+
+    async def trigger_bootloader_reset(
+        self, *, run_firmware: bool
+    ) -> ProbeResult | None:
+        """Reset into the bootloader by trying the probing methods, one by one."""
+
+        # If we have no way to enter the bootloader, don't try
+        if not self._reset_targets:
+            return None
+
+        # We don't really care which method works, just try them all at once
+        for target in self._reset_targets:
+            _LOGGER.info(f"Triggering {target.value} bootloader")
+            await self.trigger_bootloader(target)
+
+        await asyncio.sleep(BOOTLOADER_LAUNCH_DELAY)
+
+        return await self._detect_gecko_bootloader(run_firmware=run_firmware)
 
     async def dump_emberznet_config(self) -> None:
         if self.app_type != ApplicationType.EZSP:


### PR DESCRIPTION
Our current specialization code is a little hacky and some device-specific reset methods are becoming _very_ device-specific. To accommodate this and allow for easier programmatic use, I'm introducing `DeviceSpecificFlasher` and named subclasses per-device.

They can be used with a flag `flash --profile zbt2`.