### PR TITLE
Always provide default probe methods

### DIFF
--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -272,7 +272,7 @@ async def test_trigger_modem_pin_reset():
 
 
 async def test_reset_config_flasher_trigger_bootloader_reset():
-    flasher = YellowFlasher(device="/dev/ttyMOCK", probe_methods=[])
+    flasher = YellowFlasher(device="/dev/ttyMOCK")
 
     assert flasher._can_trigger_bootloader_reset() is True
 
@@ -294,7 +294,7 @@ async def test_reset_config_flasher_trigger_bootloader_reset():
 
 
 async def test_zbt1_flasher():
-    flasher = Zbt1Flasher(device="/dev/ttyMOCK", probe_methods=[])
+    flasher = Zbt1Flasher(device="/dev/ttyMOCK")
 
     assert flasher._can_trigger_bootloader_reset() is False
 

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -65,7 +65,9 @@ def register_flasher(cls: T) -> T:
 
 
 class BaseFlasher:
-    _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]]
+    _default_probe_methods: typing.Sequence[tuple[ApplicationType, int]] = (
+        DEFAULT_PROBE_METHODS
+    )
     _bootloader_launch_delay: float = 3
 
     def __init__(


### PR DESCRIPTION
MyPy never verifies if `_default_probe_methods` was provided by a subclass so the ZBT-1 and Yellow flashers failed to initialize. I've amended unit tests to only pass `device` to fully test this codepath.