### PR TITLE
Bump zigpy to 1.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
         args: ["--toml", "pyproject.toml"]
   
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.3
+    rev: v0.15.11
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
@@ -15,7 +15,7 @@ repos:
         args: ["--config", "pyproject.toml"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ requires-python = ">=3.9"
 dependencies = [
     "aiohttp",  # Explicit dependency until compatibility with async-timeout is resolved
     "tqdm",
-    "zigpy>=0.70.0",
+    "zigpy>=1.3.0",
     "crc",
     "bellows>=0.42.0",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
     'async-timeout; python_version<"3.11"',
     "typing_extensions",
-    "pyserial-asyncio-fast",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,15 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "GPL-3.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
-    "aiohttp",  # Explicit dependency until compatibility with async-timeout is resolved
+    "aiohttp",
     "tqdm",
     "zigpy>=1.3.0",
     "crc",
-    "bellows>=0.42.0",
+    "bellows>=0.49.0",
     'gpiod; platform_system=="Linux"',
     "coloredlogs",
-    'async-timeout; python_version<"3.11"',
     "typing_extensions",
 ]
 
@@ -72,6 +71,7 @@ disallow_untyped_decorators = false
 
 [tool.ruff]
 src = ["universal_silabs_flasher", "tests"]
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/tests/test_flasher.py
+++ b/tests/test_flasher.py
@@ -3,9 +3,10 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+import zigpy.serial
 import zigpy.types as t
 
-from universal_silabs_flasher.common import FlowControlSerialProtocol, Version
+from universal_silabs_flasher.common import Version
 from universal_silabs_flasher.const import (
     RESET_CONFIGS,
     ApplicationType,
@@ -78,15 +79,15 @@ async def test_baudrate_reset_pattern():
 
     assert mock_connect_protocol.mock_calls == [
         # Connect with 150 baud
-        call("/dev/ttyMOCK", 150, FlowControlSerialProtocol),
+        call("/dev/ttyMOCK", 150, zigpy.serial.SerialProtocol),
         call().__aenter__(),
         call().__aexit__(None, None, None),
         # Connect with 300 baud
-        call("/dev/ttyMOCK", 300, FlowControlSerialProtocol),
+        call("/dev/ttyMOCK", 300, zigpy.serial.SerialProtocol),
         call().__aenter__(),
         call().__aexit__(None, None, None),
         # Connect with 1200 baud
-        call("/dev/ttyMOCK", 1200, FlowControlSerialProtocol),
+        call("/dev/ttyMOCK", 1200, zigpy.serial.SerialProtocol),
         call().__aenter__(),
         call().__aenter__()._transport.write(b"BZ"),
         call().__aexit__(None, None, None),
@@ -260,13 +261,13 @@ async def test_trigger_modem_pin_reset():
         "universal_silabs_flasher.flasher.connect_protocol"
     ) as mock_connect_protocol:
         mock_uart = mock_connect_protocol.return_value.__aenter__.return_value
-        mock_uart.set_signals = AsyncMock()
+        mock_uart._transport.set_modem_pins = AsyncMock()
         await flasher._trigger_modem_pin_reset(config)
 
     assert mock_connect_protocol.mock_calls[0] == call(
-        "/dev/ttyMOCK", 115200, FlowControlSerialProtocol
+        "/dev/ttyMOCK", 115200, zigpy.serial.SerialProtocol
     )
-    assert mock_uart.set_signals.mock_calls == [
+    assert mock_uart._transport.set_modem_pins.mock_calls == [
         call(dtr=False, rts=True),
         call(dtr=True, rts=False),
     ]

--- a/tests/test_gecko_bootloader_xmodem.py
+++ b/tests/test_gecko_bootloader_xmodem.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import pathlib
-import sys
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -17,12 +16,6 @@ from universal_silabs_flasher.gecko_bootloader import (
     UploadError,
     XModemPacketType,
 )
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
 
 from .common import PairedTransport
 
@@ -92,14 +85,14 @@ class Conversation(asyncio.Protocol):
         timeout: float = 1.5,
     ) -> None:
         """Expect a command, preceded by a newline."""
-        async with asyncio_timeout(timeout):
+        async with asyncio.timeout(timeout):
             data = await self._reader.read(len(command) + 1)
         assert data.endswith(command)
 
     async def expect_packet(self, number: int, timeout: float = 2.0) -> bytes:
         """Read and validate a full XMODEM packet, returning its payload."""
         # 3 bytes header, 128 bytes payload, 2 bytes CRC
-        async with asyncio_timeout(timeout):
+        async with asyncio.timeout(timeout):
             data = await self._reader.read(133)
 
         assert data[0] == XModemPacketType.SOH
@@ -113,7 +106,7 @@ class Conversation(asyncio.Protocol):
         return payload
 
     async def expect_eot(self, timeout: float = 1.0) -> None:
-        async with asyncio_timeout(timeout):
+        async with asyncio.timeout(timeout):
             data = await self._reader.read(1)
         assert data == bytes([XModemPacketType.EOT])
 
@@ -177,7 +170,7 @@ async def test_xmodem_happy_path() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FULL_FIRMWARE
@@ -228,7 +221,7 @@ async def test_xmodem_with_retries() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -274,7 +267,7 @@ async def test_xmodem_timeout() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -299,7 +292,7 @@ async def test_xmodem_cancellation() -> None:
     await conversation.send_can()
 
     with pytest.raises(ReceiverCancelled):
-        async with asyncio_timeout(1):
+        async with asyncio.timeout(1):
             await upload_task
 
 
@@ -383,7 +376,7 @@ async def test_xmodem_multiple_c_bytes() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -421,7 +414,7 @@ async def test_xmodem_spurious_ack() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -459,7 +452,7 @@ async def test_xmodem_spurious_nak() -> None:
     await conversation.expect_command(GeckoBootloaderOption.EBL_INFO)
     await conversation.send_menu()
 
-    async with asyncio_timeout(UPLOAD_COMPLETION_TIMEOUT):
+    async with asyncio.timeout(UPLOAD_COMPLETION_TIMEOUT):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -577,7 +570,7 @@ async def test_xmodem_empty_buffer_during_transfer() -> None:
     await conversation.send_upload_complete()
     await conversation.send_menu()
 
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         await upload_task
 
 
@@ -637,7 +630,7 @@ async def test_xmodem_reverts_to_line_parsing() -> None:
     await conversation.send_menu()
 
     # The upload task should complete successfully
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -673,7 +666,7 @@ async def test_xmodem_reverts_to_line_parsing_byte_by_byte() -> None:
     await conversation.send_menu()
 
     # The upload task should complete successfully
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -710,7 +703,7 @@ async def test_xmodem_reverts_to_line_parsing_with_write_aggregation() -> None:
     await conversation.send_menu()
 
     # The upload task should complete successfully
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         await upload_task
 
     assert received_firmware == FIRMWARE
@@ -742,7 +735,7 @@ async def test_parser_needs_more_data() -> None:
     await conversation.send(rest_of_menu)
 
     # The info task should complete
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         await info_task
 
 

--- a/tests/test_spinel.py
+++ b/tests/test_spinel.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from unittest.mock import MagicMock, call
 
 import pytest
 
+from universal_silabs_flasher.common import crc16_kermit
+import universal_silabs_flasher.spinel as spinel
 from universal_silabs_flasher.spinel import (
     HDLCLiteFrame,
     SpinelFrame,
@@ -14,14 +15,6 @@ from universal_silabs_flasher.spinel import (
     SpinelProtocol,
 )
 from universal_silabs_flasher.spinel_types import CommandID, PackedUInt21, PropertyID
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
-from universal_silabs_flasher.common import crc16_kermit
-import universal_silabs_flasher.spinel as spinel
 
 from .common import PairedTransport
 
@@ -159,7 +152,7 @@ async def test_ignore_duplicate_response(caplog: pytest.CapLogFixture) -> None:
         await asyncio.sleep(0.01)
 
     # The future should be resolved with the first response
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         result = await fut
 
     assert result == response1
@@ -241,7 +234,7 @@ async def test_iter_property_changes() -> None:
         )
         await conversation.send(HDLCLiteFrame(data=response.serialize()).serialize())
 
-    async with asyncio_timeout(1):
+    async with asyncio.timeout(1):
         results = [await queue.get() for _ in range(5)]
 
     assert results == [f"test {i}".encode("ascii") for i in range(5)]

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -7,21 +7,13 @@ import dataclasses
 import functools
 import logging
 import re
-import sys
 import typing
 
 import crc
 import zigpy.serial
 
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout  # pragma: no cover
-else:
-    from asyncio import timeout as asyncio_timeout  # pragma: no cover
-
 if typing.TYPE_CHECKING:
-    from typing_extensions import Self
-
-__all__ = ["asyncio_timeout"]
+    from typing import Self
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +114,7 @@ class StateMachine:
         self._futures_for_state[state].append(future)
 
         try:
-            async with asyncio_timeout(timeout):
+            async with asyncio.timeout(timeout):
                 return await future
         finally:
             # Always clean up the future
@@ -140,7 +132,7 @@ async def connect_protocol(
 ) -> typing.AsyncIterator[P]:
     loop = asyncio.get_running_loop()
 
-    async with asyncio_timeout(CONNECT_TIMEOUT):
+    async with asyncio.timeout(CONNECT_TIMEOUT):
         _, protocol = await zigpy.serial.create_serial_connection(
             loop=loop,
             protocol_factory=factory,

--- a/universal_silabs_flasher/common.py
+++ b/universal_silabs_flasher/common.py
@@ -142,7 +142,7 @@ async def connect_protocol(
 
     async with asyncio_timeout(CONNECT_TIMEOUT):
         _, protocol = await zigpy.serial.create_serial_connection(
-            loop=loop,  # type: ignore[arg-type]  # zigpy expects BaseEventLoop
+            loop=loop,
             protocol_factory=factory,
             url=port,
             baudrate=baudrate,
@@ -226,49 +226,3 @@ class Version:
             return f"{concatenated!r}"
 
         return f"{concatenated!r} ({comparable})"
-
-
-class FlowControlSerialProtocol(zigpy.serial.SerialProtocol):
-    def _set_signals(
-        self,
-        *,
-        rts: bool | None = None,
-        cts: bool | None = None,
-        dtr: bool | None = None,
-    ) -> None:
-        assert self._transport is not None
-        assert self._transport.serial is not None
-
-        if rts is not None:
-            self._transport.serial.rts = rts
-
-        if cts is not None:
-            self._transport.serial.cts = cts
-
-        if dtr is not None:
-            self._transport.serial.dtr = dtr
-
-    async def set_signals(
-        self,
-        *,
-        rts: bool | None = None,
-        cts: bool | None = None,
-        dtr: bool | None = None,
-    ) -> None:
-        assert self._transport is not None
-
-        _LOGGER.debug(
-            "Setting UART signals: rts=%s, cts=%s, dtr=%s",
-            int(rts) if rts is not None else "-",
-            int(cts) if cts is not None else "-",
-            int(dtr) if dtr is not None else "-",
-        )
-
-        if hasattr(self._transport, "set_signals"):
-            await self._transport.set_signals(rts=rts, cts=cts, dtr=dtr)
-            return
-
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None, lambda: self._set_signals(rts=rts, cts=cts, dtr=dtr)
-        )

--- a/universal_silabs_flasher/cpc.py
+++ b/universal_silabs_flasher/cpc.py
@@ -9,7 +9,7 @@ from zigpy.serial import SerialProtocol
 import zigpy.types
 
 from . import cpc_types
-from .common import BufferTooShort, Version, asyncio_timeout, crc16_ccitt
+from .common import BufferTooShort, Version, crc16_ccitt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -375,9 +375,9 @@ class CPCProtocol(SerialProtocol):
                 self.send_data(frame.serialize())
 
                 try:
-                    async with asyncio_timeout(timeout):
+                    async with asyncio.timeout(timeout):
                         return await asyncio.shield(future)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _LOGGER.debug(
                         "Failed to send %s, trying again in %0.2fs (attempt %s of %s)",
                         frame,

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -13,13 +13,7 @@ import bellows.types
 import zigpy.serial
 import zigpy.types
 
-from .common import (
-    PROBE_TIMEOUT,
-    Version,
-    asyncio_timeout,
-    connect_protocol,
-    pad_to_multiple,
-)
+from .common import PROBE_TIMEOUT, Version, connect_protocol, pad_to_multiple
 from .const import (
     DEFAULT_PROBE_METHODS,
     RESET_CONFIGS,
@@ -265,7 +259,7 @@ class BaseFlasher:
                 probe_result = await self.probe_gecko_bootloader(
                     run_firmware=run_firmware, baudrate=baudrate
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 continue
             else:
                 return probe_result
@@ -332,7 +326,7 @@ class BaseFlasher:
 
             try:
                 result = await probe_funcs[probe_method](baudrate=baudrate)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.debug("Probe timed out")
                 continue
 
@@ -390,25 +384,25 @@ class BaseFlasher:
             pass
         elif self.app_type is ApplicationType.CPC:
             async with self._connect_cpc(self.app_baudrate) as cpc:
-                async with asyncio_timeout(PROBE_TIMEOUT):
+                async with asyncio.timeout(PROBE_TIMEOUT):
                     await cpc.enter_bootloader()
         elif self.app_type is ApplicationType.SPINEL:
             async with self._connect_spinel(self.app_baudrate) as spinel:
-                async with asyncio_timeout(PROBE_TIMEOUT):
+                async with asyncio.timeout(PROBE_TIMEOUT):
                     await spinel.enter_bootloader()
         elif self.app_type is ApplicationType.ROUTER:
             async with self._connect_router(self.app_baudrate) as router:
-                async with asyncio_timeout(PROBE_TIMEOUT):
+                async with asyncio.timeout(PROBE_TIMEOUT):
                     await router.enter_bootloader()
         elif self.app_type is ApplicationType.ZWAVE:
             async with self._connect_zwave(self.app_baudrate) as zwave:
-                async with asyncio_timeout(PROBE_TIMEOUT):
+                async with asyncio.timeout(PROBE_TIMEOUT):
                     await zwave.enter_bootloader()
         elif self.app_type is ApplicationType.EZSP:
             async with self._connect_ezsp(self.app_baudrate) as ezsp:
                 try:
                     res = await ezsp.launchStandaloneBootloader(mode=0x01)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _LOGGER.warning(
                         "Application failed to respond to bootloader launching command."
                         " Assuming bootloader has launched."
@@ -651,7 +645,7 @@ class Zbt2Flasher(DeviceSpecificFlasher):
             _LOGGER.debug("Expected failure when sending reset command: %r", exc)
 
         # Wait for a while for the stick to come back
-        async with asyncio_timeout(self._reconnect_timeout):
+        async with asyncio.timeout(self._reconnect_timeout):
             while True:
                 try:
                     await self._send_esp32_command("BZ")

--- a/universal_silabs_flasher/flasher.py
+++ b/universal_silabs_flasher/flasher.py
@@ -10,11 +10,11 @@ from typing import cast
 import bellows.config
 import bellows.ezsp
 import bellows.types
+import zigpy.serial
 import zigpy.types
 
 from .common import (
     PROBE_TIMEOUT,
-    FlowControlSerialProtocol,
     Version,
     asyncio_timeout,
     connect_protocol,
@@ -210,7 +210,7 @@ class BaseFlasher:
         # Baudrate command mode uses a pattern of baudrates to enter a command mode
         for baudrate in config.baudrates:
             async with connect_protocol(
-                self._device, baudrate, FlowControlSerialProtocol
+                self._device, baudrate, zigpy.serial.SerialProtocol
             ) as uart:
                 await asyncio.sleep(config.delay_after_each)
 
@@ -224,10 +224,11 @@ class BaseFlasher:
     async def _trigger_modem_pin_reset(self, config: ModemPinResetConfig) -> None:
         # The baudrate isn't necessary, since we're just using flow control pins
         async with connect_protocol(
-            self._device, 115200, FlowControlSerialProtocol
+            self._device, 115200, zigpy.serial.SerialProtocol
         ) as uart:
+            assert uart._transport is not None
             for pattern in config.pattern:
-                await uart.set_signals(**pattern.pins)
+                await uart._transport.set_modem_pins(**pattern.pins)  # type: ignore[arg-type]
                 await asyncio.sleep(pattern.delay_after)
 
     async def _trigger_gpio_reset(self, config: GpioResetConfig) -> None:

--- a/universal_silabs_flasher/gecko_bootloader.py
+++ b/universal_silabs_flasher/gecko_bootloader.py
@@ -10,7 +10,7 @@ import typing
 from zigpy.serial import SerialProtocol
 import zigpy.types
 
-from .common import PROBE_TIMEOUT, StateMachine, Version, asyncio_timeout, crc16_ccitt
+from .common import PROBE_TIMEOUT, StateMachine, Version, crc16_ccitt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ UPLOAD_STATUS_REGEX = re.compile(
 )  # fmt: skip
 
 
-class State(str, enum.Enum):
+class State(enum.StrEnum):
     WAITING_FOR_MENU = "waiting_for_menu"
     IN_MENU = "in_menu"
     WAITING_XMODEM_READY = "waiting_xmodem_ready"
@@ -137,7 +137,7 @@ class GeckoBootloaderProtocol(SerialProtocol):
 
     async def probe(self) -> Version:
         """Attempt to communicate with the bootloader."""
-        async with asyncio_timeout(PROBE_TIMEOUT):
+        async with asyncio.timeout(PROBE_TIMEOUT):
             return await self.ebl_info()
 
     async def ebl_info(self) -> Version:
@@ -162,9 +162,9 @@ class GeckoBootloaderProtocol(SerialProtocol):
         self.send_data(GeckoBootloaderOption.RUN_FIRMWARE)
 
         try:
-            async with asyncio_timeout(RUN_APPLICATION_DELAY):
+            async with asyncio.timeout(RUN_APPLICATION_DELAY):
                 await self._state_machine.wait_for_state(State.IN_MENU)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # The menu did not appear so the application must be running
             return
         else:
@@ -267,9 +267,9 @@ class GeckoBootloaderProtocol(SerialProtocol):
         # and transitions: UPLOAD_DONE -> WAITING_FOR_MENU -> IN_MENU.
         # (if menu is buffered). The menu is sometimes sent immediately after upload.
         try:
-            async with asyncio_timeout(MENU_AFTER_UPLOAD_TIMEOUT):
+            async with asyncio.timeout(MENU_AFTER_UPLOAD_TIMEOUT):
                 await self._state_machine.wait_for_state(State.IN_MENU)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # If not, trigger it manually
             await self.ebl_info()
 

--- a/universal_silabs_flasher/router.py
+++ b/universal_silabs_flasher/router.py
@@ -7,14 +7,14 @@ import re
 
 from zigpy.serial import SerialProtocol
 
-from .common import PROBE_TIMEOUT, StateMachine, Version, asyncio_timeout
+from .common import PROBE_TIMEOUT, StateMachine, Version
 
 _LOGGER = logging.getLogger(__name__)
 
 ROUTER_INFO_REGEX = re.compile(rb"stack ver\. \[(?P<version>.*?)\]\r\n")
 
 
-class State(str, enum.Enum):
+class State(enum.StrEnum):
     STARTUP = "startup"
     BOOTWAIT = "bootwait"
     INFO = "info"
@@ -37,7 +37,7 @@ class RouterProtocol(SerialProtocol):
 
     async def probe(self) -> Version:
         """Attempt to communicate with the router."""
-        async with asyncio_timeout(PROBE_TIMEOUT):
+        async with asyncio.timeout(PROBE_TIMEOUT):
             return await self.router_info()
 
     async def router_info(self) -> Version:

--- a/universal_silabs_flasher/spinel.py
+++ b/universal_silabs_flasher/spinel.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from collections.abc import Callable
 import dataclasses
 import logging
 import typing
-from typing import Callable
 
 from zigpy.serial import SerialProtocol
 import zigpy.types
 
-from .common import Version, asyncio_timeout, crc16_kermit
+from .common import Version, crc16_kermit
 from .spinel_types import (
     CommandID,
     HDLCSpecial,
@@ -258,9 +258,9 @@ class SpinelProtocol(SerialProtocol):
                 self.send_data(HDLCLiteFrame(data=new_frame.serialize()).serialize())
 
                 try:
-                    async with asyncio_timeout(timeout):
+                    async with asyncio.timeout(timeout):
                         return await asyncio.shield(future)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _LOGGER.debug(
                         "Failed to send %s, trying again in %0.2fs (attempt %s of %s)",
                         frame,
@@ -356,10 +356,10 @@ class SpinelProtocol(SerialProtocol):
             return
 
         try:
-            async with asyncio_timeout(RESET_TIMEOUT):
+            async with asyncio.timeout(RESET_TIMEOUT):
                 await self.wait_for_property(
                     PropertyID.LAST_STATUS, Status.RESET_POWER_ON.serialize()
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # OTBR itself uses this logic, we match it
             _LOGGER.debug("Device did not respond to reset, continuing")

--- a/universal_silabs_flasher/zwave.py
+++ b/universal_silabs_flasher/zwave.py
@@ -4,12 +4,12 @@ import asyncio
 import dataclasses
 import logging
 import typing
+from typing import Self
 
-from typing_extensions import Self
 from zigpy.serial import SerialProtocol
 import zigpy.types as t
 
-from .common import BufferTooShort, Version, asyncio_timeout
+from .common import BufferTooShort, Version
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -175,9 +175,9 @@ class ZWaveProtocol(SerialProtocol):
                 self.send_data(frame.serialize())
 
                 try:
-                    async with asyncio_timeout(timeout):
+                    async with asyncio.timeout(timeout):
                         return await future
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     _LOGGER.debug(
                         "Failed to send %r, trying again in %0.2fs (attempt %s of %s)",
                         frame,


### PR DESCRIPTION
Bump zigpy to [1.3.0](https://github.com/zigpy/zigpy/releases/tag/1.3.0), which now has a hard dependency on [serialx](https://github.com/puddly/serialx). This simplifies a few use cases for modem pin toggling but more importantly drops serialx as an implicit dependency and makes it explicit.