### PR TITLE
Add erase-nvm3 command: bootloader-level NVM3 erase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ $ pip install universal-silabs-flasher
 ```console
 usage: universal-silabs-flasher [-h] [-v] [--device DEVICE] [--probe-methods PROBE_METHODS]
                                 [--bootloader-reset BOOTLOADER_RESET]
-                                {dump-gbl-metadata,probe,write-ieee,flash} ...
+                                {dump-gbl-metadata,probe,write-ieee,flash,erase-nvm3} ...
 
 positional arguments:
-  {dump-gbl-metadata,probe,write-ieee,flash}
+  {dump-gbl-metadata,probe,write-ieee,flash,erase-nvm3}
 
 options:
   -h, --help            show this help message and exit
@@ -78,6 +78,32 @@ $ universal-silabs-flasher \
     --firmware ncp-uart-hw-v7.4.5.0-zbdonglee-115200.gbl
 ```
 
+
+## Erasing NVM3
+Erase the NVM3 token store (network settings, keys, frame counters) via the Gecko
+bootloader. Because this works at the bootloader level, it can recover a device
+whose application firmware no longer boots — for example after a firmware
+downgrade left an incompatible NVM3 format behind:
+
+```bash
+$ universal-silabs-flasher \
+    --device /dev/cu.SLAB_USBtoUART \
+    --bootloader-reset rts_dtr \
+    erase-nvm3 \
+    --address 0x08176000 \
+    --size 40960
+```
+
+NVM3 sits at the top of main flash, so `--address` is
+`flash base + flash size - NVM3 size`. The size is firmware-specific (the SDK
+default is `40960`; `32768` is also common) and must be a multiple of the flash
+page size. Per-chip geometry is documented in
+[Nerivec/silabs-firmware-recovery](https://github.com/Nerivec/silabs-firmware-recovery),
+whose published recovery images this command replicates by generating an
+equivalent erase GBL locally.
+
+**This is destructive**: the device loses its network and must be re-joined or
+re-commissioned afterwards.
 
 ## Writing IEEE address
 Ensure a target device running EmberZNet firmware has the correct node IEEE address:

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -84,3 +84,42 @@ def test_firmware_gbl_valid_with_metadata_v2():
             "sdk_version": "4.4.4",
         },
     )
+
+
+def test_generate_nvm3_erase_gbl():
+    import zlib
+
+    fw = firmware.generate_nvm3_erase_gbl(address=0x08176000, size=40960)
+    data = fw.serialize()
+
+    # Round-trips through the strict GBL parser (validates structure)
+    parsed = firmware.parse_firmware_image(data)
+    assert isinstance(parsed, firmware.GBLImage)
+    assert parsed.serialize() == data
+
+    # Whole-file CRC32 leaves the standard Silabs residue
+    assert zlib.crc32(data) == 0x2144DF1C
+
+    # No metadata tag in the generated image
+    with pytest.raises(KeyError):
+        parsed.get_nabucasa_metadata()
+
+    # Program-data tag covers the requested region with erased-flash bytes
+    prog = parsed.get_first_tag(firmware.GBLTagId.PROGRAM_DATA2)
+    assert int.from_bytes(prog[:4], "little") == 0x08176000
+    assert prog[4:] == b"\xff" * 40960
+
+
+@pytest.mark.parametrize(
+    ("address", "size"),
+    [
+        (0x08176000, 0),
+        (0x08176000, -4096),
+        (0x08176001, 4096),
+        (0x08176000, 4097),
+        (0xFFFFF000, 40960),
+    ],
+)
+def test_generate_nvm3_erase_gbl_validation(address, size):
+    with pytest.raises(ValueError):
+        firmware.generate_nvm3_erase_gbl(address=address, size=size)

--- a/universal_silabs_flasher/firmware.py
+++ b/universal_silabs_flasher/firmware.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 import logging
 import typing
+import zlib
 
 from zigpy.ota.validators import ValidationError, parse_silabs_ebl, parse_silabs_gbl
 import zigpy.types as zigpy_t
@@ -14,6 +15,9 @@ from .const import LEGACY_FIRMWARE_TYPE_REMAPPING, FirmwareImageType
 _LOGGER = logging.getLogger(__name__)
 
 NABUCASA_METADATA_VERSION = 2
+
+# Byte-exact header payload used by plain (unsigned, unencrypted) GBL v3 images
+GBL_PLAIN_HEADER_PAYLOAD = bytes.fromhex("0000000300000000")
 
 
 class GBLTagId(zigpy_t.enum32):
@@ -202,6 +206,53 @@ class GBLImage(FirmwareImage[GBLTagId]):
         metadata = self.get_first_tag(GBLTagId.METADATA)
 
         return NabuCasaMetadata.from_json(json.loads(metadata))
+
+
+def generate_nvm3_erase_gbl(address: int, size: int) -> GBLImage:
+    """Generate a GBL image that erases a flash region by programming `0xFF`.
+
+    Intended for wiping the NVM3 token store (located at the top of main
+    flash) via the Gecko bootloader, restoring a device whose application
+    cannot boot — e.g. after an EmberZNet downgrade left an incompatible
+    NVM3 format behind. Programming `0xFF` makes the bootloader erase the
+    affected pages, which is exactly the erased-flash state NVM3 expects
+    for a fresh initialization.
+
+    The layout mirrors the images published by
+    https://github.com/Nerivec/silabs-firmware-recovery: a plain v3 header,
+    an all-zero APP_INFO tag, one PROGRAM_DATA tag covering the region, and
+    an END tag with the file CRC32.
+    """
+    if size <= 0:
+        raise ValueError(f"Erase size must be positive, got {size}")
+
+    if size % 4 != 0 or address % 4 != 0:
+        raise ValueError(
+            f"Erase address and size must be multiples of 4,"
+            f" got address=0x{address:08X} size={size}"
+        )
+
+    if not 0 <= address <= 0xFFFFFFFF - size:
+        raise ValueError(f"Erase region 0x{address:08X}+{size} is out of range")
+
+    tags: list[tuple[GBLTagId, bytes]] = [
+        (GBLTagId.HEADER, GBL_PLAIN_HEADER_PAYLOAD),
+        (GBLTagId.APP_INFO, bytes(28)),
+        (
+            GBLTagId.PROGRAM_DATA2,
+            address.to_bytes(4, "little") + b"\xff" * size,
+        ),
+    ]
+
+    partial = b"".join(
+        tag_id.serialize() + len(value).to_bytes(4, "little") + value
+        for tag_id, value in tags
+    )
+    partial += GBLTagId.END.serialize() + (4).to_bytes(4, "little")
+
+    tags.append((GBLTagId.END, zlib.crc32(partial).to_bytes(4, "little")))
+
+    return GBLImage(tags=tags)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/universal_silabs_flasher/flash.py
+++ b/universal_silabs_flasher/flash.py
@@ -17,7 +17,7 @@ import zigpy.ota.validators
 import zigpy.types
 
 from .const import DEFAULT_PROBE_METHODS, ApplicationType, ResetTarget
-from .firmware import parse_firmware_image
+from .firmware import generate_nvm3_erase_gbl, parse_firmware_image
 from .flasher import DEVICE_SPECIFIC_FLASHERS, BaseFlasher, Flasher
 from .gecko_bootloader import XMODEM_BLOCK_SIZE, ReceiverCancelled
 
@@ -87,6 +87,14 @@ def parse_probe_methods(value: str) -> list[tuple[ApplicationType, int]]:
         result.append((app_type, baudrate))
 
     return result
+
+
+def parse_any_int(value: str) -> int:
+    """Parse a decimal or prefixed (0x/0o/0b) integer argument."""
+    try:
+        return int(value, 0)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
 
 
 def parse_reset_methods(value: str) -> list[ResetTarget]:
@@ -188,6 +196,29 @@ async def main(argv: list[str] | None = None) -> None:
         ),
     )
 
+    # erase-nvm3
+    erase_nvm3_parser = subparsers.add_parser("erase-nvm3", parents=[global_parser])
+    erase_nvm3_parser.add_argument(
+        "--address",
+        required=True,
+        type=parse_any_int,
+        help=(
+            "Start address of the NVM3 region (decimal or 0x-prefixed hex)."
+            " NVM3 sits at the top of main flash:"
+            " flash base + flash size - NVM3 size."
+        ),
+    )
+    erase_nvm3_parser.add_argument(
+        "--size",
+        required=True,
+        type=parse_any_int,
+        help=(
+            "Size of the NVM3 region in bytes (decimal or 0x-prefixed hex),"
+            " e.g. 40960 (the SDK default) or 32768. Must be a multiple of the"
+            " device's flash page size."
+        ),
+    )
+
     args = parser.parse_args(argv)
 
     coloredlogs.install(
@@ -232,6 +263,8 @@ async def main(argv: list[str] | None = None) -> None:
         await _cmd_write_ieee(args, flasher)
     elif args.command == "flash":
         await _cmd_flash(args, flasher, getattr(args, "verbose", 0))
+    elif args.command == "erase-nvm3":
+        await _cmd_erase_nvm3(args, flasher, getattr(args, "verbose", 0))
 
 
 async def _cmd_dump_gbl_metadata(args: argparse.Namespace) -> None:
@@ -284,6 +317,54 @@ async def _cmd_write_ieee(args: argparse.Namespace, flasher: Flasher) -> None:
     except (ValueError, RuntimeError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+
+async def _cmd_erase_nvm3(
+    args: argparse.Namespace, flasher: BaseFlasher, verbosity: int
+) -> None:
+    try:
+        fw_image = generate_nvm3_erase_gbl(address=args.address, size=args.size)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    firmware_data = fw_image.serialize()
+
+    _LOGGER.info(
+        "Erasing NVM3 region 0x%08X - 0x%08X (%d bytes)",
+        args.address,
+        args.address + args.size - 1,
+        args.size,
+    )
+
+    try:
+        await flasher.probe_app_type()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    await flasher.enter_bootloader()
+
+    with tqdm.tqdm(
+        total=len(firmware_data),
+        desc="NVM3 erase",
+        unit="B",
+        unit_scale=True,
+        disable=verbosity > 1,
+    ) as pbar:
+        try:
+            await flasher.flash_firmware(
+                fw_image,
+                run_firmware=True,
+                progress_callback=lambda current, _: pbar.update(XMODEM_BLOCK_SIZE),
+            )
+        except ReceiverCancelled:
+            print(
+                "Error: The erase image was rejected by the device. The bootloader"
+                " may require signed images.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 async def _cmd_flash(


### PR DESCRIPTION
Implements #144: a bootloader-level NVM3 erase, usable even when the application firmware cannot boot.

### What

New `erase-nvm3` subcommand:

```
universal-silabs-flasher --device ... --bootloader-reset rts_dtr erase-nvm3 --address 0x08176000 --size 40960
```

`generate_nvm3_erase_gbl()` builds a plain GBL in memory — v3 header, zeroed `APP_INFO`, one program-data tag covering the region with `0xFF` (the bootloader erases the affected pages), and a CRC32 `END` tag — then uploads it through the existing `flash_firmware()` path. The layout is byte-compatible with the recovery images published by [Nerivec/silabs-firmware-recovery](https://github.com/Nerivec/silabs-firmware-recovery); generating locally avoids bundling or downloading third-party binaries and works for any geometry.

### Why bootloader-level (vs. #103's EZSP factory reset)

An EZSP-level reset requires a booting application. The motivating failure (real case, Sonoff Dongle-PMG24/EFR32MG24): a newer-SDK EmberZNet build ran once and migrated NVM3; after downgrading, no 8.2.x image would boot — every flash "succeeded" but the app stayed dead, and only an NVM3 erase via the bootloader recovered it. Verified on that hardware using an equivalent hand-fed erase GBL (via ember-zli); this PR reproduces that image generation exactly (validated round-trip through `parse_firmware_image`, whole-file CRC residue `0x2144DF1C`).

### Notes

* Address/size are explicit (decimal or `0x`-hex); NVM3 is at `flash_base + flash_size − nvm3_size`. README documents this and points at silabs-firmware-recovery for per-chip geometry.
* Destructive by design; README carries a warning.
* Tests: generator round-trip/CRC/tag-layout + argument validation. `pytest tests/ --ignore=tests/test_flash_cli.py`: 98 passed (that file needs `aioresponses`, unavailable in my env — unrelated to this change).
